### PR TITLE
export function for createLlmFunctionExecutor, add error if using dia…

### DIFF
--- a/src/executor/_functions.ts
+++ b/src/executor/_functions.ts
@@ -10,6 +10,7 @@ import { BasePrompt } from "@/prompt";
 import { BaseState } from "@/state";
 import { CoreExecutor } from "./core";
 import { LlmExecutor } from "./llm";
+import { LlmExecutorWithFunctions } from "./llm-openai-function";
 
 /**
  * Function to create a core executor.
@@ -38,10 +39,25 @@ export function createLlmExecutor<
   Llm extends BaseLlm<any>,
   Prompt extends BasePrompt<any>,
   Parser extends BaseParser,
-  State extends BaseState
+  State extends BaseState,
 >(
   llmConfiguration: ExecutorWithLlmOptions<Llm, Prompt, Parser, State>,
   options?: CoreExecutorExecuteOptions<LlmExecutorHooks>
 ) {
   return new LlmExecutor<Llm, Prompt, Parser, State>(llmConfiguration, options);
+}
+
+export function createLlmFunctionExecutor<
+  Llm extends BaseLlm,
+  Prompt extends BasePrompt<Record<string, any>>,
+  Parser extends BaseParser,
+  State extends BaseState,
+>(
+  llmConfiguration: ExecutorWithLlmOptions<Llm, Prompt, Parser, State>,
+  options?: CoreExecutorExecuteOptions<LlmExecutorHooks>
+) {
+  return new LlmExecutorWithFunctions<Llm, Prompt, Parser, State>(
+    llmConfiguration,
+    options
+  );
 }

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -5,4 +5,8 @@ export {
   LlmExecutorWithFunctions,
   LlmExecutorOpenAiFunctions,
 } from "./llm-openai-function";
-export { createCoreExecutor, createLlmExecutor } from "./_functions";
+export {
+  createCoreExecutor,
+  createLlmExecutor,
+  createLlmFunctionExecutor,
+} from "./_functions";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 export { useExecutors, createCallableExecutor } from "@/plugins/callable";
-export { createCoreExecutor, createLlmExecutor } from "@/executor/_functions";
+export {
+  createCoreExecutor,
+  createLlmExecutor,
+  createLlmFunctionExecutor,
+} from "@/executor/_functions";
 export { BaseExecutor } from "@/executor/_base";
 export * as utils from "./utils";
 export { useLlm } from "./llm";

--- a/src/interfaces/errors.ts
+++ b/src/interfaces/errors.ts
@@ -3,6 +3,7 @@ export type ErrorContextMap = {
   llm: { provider: string; model: string; error: string };
   prompt: { prompt: any; provider?: string; model?: string; error: string };
   parser: { parser: string; output: any; error: string };
+  state: { module: string; error: string };
 };
 
 export type ErrorCodes = keyof ErrorContextMap;

--- a/src/state/dialogue.ts
+++ b/src/state/dialogue.ts
@@ -5,6 +5,7 @@ import {
 } from "@/types";
 import { BaseStateItem } from "./item";
 import { maybeStringifyJSON } from "@/utils";
+import { LlmExeError } from "@/utils/modules/errors";
 
 export class Dialogue extends BaseStateItem<IChatMessages> {
   public name: string;
@@ -64,6 +65,12 @@ export class Dialogue extends BaseStateItem<IChatMessages> {
   setFunctionCallMessage(input: {
     function_call: { name: string; arguments: string };
   }) {
+    if (!input?.function_call) {
+      throw new LlmExeError(`Invalid arguments`, "state", {
+        error: `Invalid arguments: missing required function_call`,
+        module: "dialogue",
+      });
+    }
     this.value.push({
       role: "assistant",
       function_call: {


### PR DESCRIPTION
This pull request introduces a new executor type, `createLlmFunctionExecutor`, along with related updates to integrate it into the codebase. Additionally, it enhances error handling by expanding the `ErrorContextMap` and introducing a new error type, `LlmExeError`, for state validation.

### New Executor Functionality:

* **Added `createLlmFunctionExecutor`**: Introduced a new function in `src/executor/_functions.ts` to create an executor using `LlmExecutorWithFunctions`, enabling support for function-based LLM execution.
* **Export Updates**: Updated exports in `src/executor/index.ts` and `src/index.ts` to include `createLlmFunctionExecutor`. [[1]](diffhunk://#diff-e6f7ec6ccfd8fa064712b0a742eaf479cb87fcd850f4e0af397ad1721620e0fcL8-R12) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L2-R6)

### Error Handling Enhancements:

* **Extended `ErrorContextMap`**: Added a new `state` context to `ErrorContextMap` in `src/interfaces/errors.ts` to handle state-related errors.
* **Introduced `LlmExeError`**: Added a custom error type, `LlmExeError`, and integrated it into `src/state/dialogue.ts` for validating `function_call` inputs in the `Dialogue` class. (F3cdc614L3R3, [src/state/dialogue.tsR68-R73](diffhunk://#diff-f5c687987414293c5ea6ddf078d5010c28cdf9309132c6f3f858d99ba53a0cc0R68-R73))