### PR TITLE
docs: fix incorrect URLs, copy-paste errors, and missing content

### DIFF
--- a/docs/embeddings/amazon.md
+++ b/docs/embeddings/amazon.md
@@ -1,7 +1,7 @@
 
 # Amazon Embeddings
 
-When using Amazon models, llm-exe will make POST requests to `https://api.openai.com/v1/chat/completions`. All models are supported if you pass `openai.chat.v1` as the first argument, and then specify a model in the options.
+When using Amazon embeddings, llm-exe will make POST requests to the AWS Bedrock endpoint for your configured region.
 
 ## Basic Usage
 

--- a/docs/embeddings/index.md
+++ b/docs/embeddings/index.md
@@ -13,4 +13,4 @@ Embeddings is a wrapper around various embeddings providers, making your functio
 - Amazon Embedding
 
 ## Adding Custom Providers
-If you need to register additional embeddings's to be used, you can...
+Custom embedding providers are not currently supported. If you need an embedding provider that isn't listed above, please open an issue.

--- a/docs/embeddings/openai.md
+++ b/docs/embeddings/openai.md
@@ -1,6 +1,6 @@
 # OpenAI Embeddings
 
-When using OpenAi models, llm-exe will make POST requests to `https://api.openai.com/v1/chat/completions`. All models are supported if you pass `openai.chat.v1` as the first argument, and then specify a model in the options.
+When using OpenAI embeddings, llm-exe will make POST requests to `https://api.openai.com/v1/embeddings`.
 
 ## Basic Usage
 

--- a/docs/examples/bots/extract.md
+++ b/docs/examples/bots/extract.md
@@ -79,7 +79,7 @@ chatHistory.push({
     content: "I'm going to be in berlin"
 });
 
-const response2 = await identifyIntent().execute({
+const response2 = await extractInformation({
     input: "I get there the 14th and leave the 18th",
     chatHistory
 }, schema);

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -13,25 +13,23 @@ This example does not use llm-exe
 
 This example uses the OpenAi nodejs package directly. Its likely where you'd start. It works, but as I'll explain below, its more of a proof of concept.
 ```typescript
-const { Configuration, OpenAIApi } = require("openai");
+import OpenAI from "openai";
 
-const openAiClient = new OpenAIApi(
-  new Configuration({
-    apiKey: process.env.OPENAI_API_KEY,
-  })
-);
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
 
 export async function YesOrNoBot(
   question: string
 ): Promise<{ response: string }> {
   const model = "gpt-4o-mini";
 
-  const messages = [
+  const messages: OpenAI.ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content: `You are not an assistant, I need you to reply with only 
-  'yes' or 'no' as an answer to the question below. Do not explain yourself 
-  or ask questions. Answer with only yes or no.`;,
+      content: `You are not an assistant, I need you to reply with only
+  'yes' or 'no' as an answer to the question below. Do not explain yourself
+  or ask questions. Answer with only yes or no.`,
     },
     {
       role: "user",
@@ -43,18 +41,16 @@ export async function YesOrNoBot(
     },
   ];
 
-  const response = await openAiClient.createChatCompletion({
+  const response = await openai.chat.completions.create({
     model: model,
     messages,
     temperature: 0,
     max_tokens: 160,
   });
 
-  const { data } = response;
-  const [choice] = data.choices;
-  const { message, finish_reason } = choice;
-  const { content = "" } = message;
-  if (finish_reason !== "stop") {
+  const [choice] = response.choices;
+  const content = choice.message?.content ?? "";
+  if (choice.finish_reason !== "stop") {
     console.log("error finish reason");
   }
   let cleanResponse = content.trim();

--- a/docs/llm/anthropic.options.part.md
+++ b/docs/llm/anthropic.options.part.md
@@ -8,4 +8,4 @@
 | stream          | boolean | null              | Note: Not supported yet.                                                         |
 | stop            | ?       | null              | Maps to stop_sequences. See Anthropic Docs                                       |
 
-Anthropic Docs: [link](https://platform.openai.com/docs/api-reference/completions)
+Anthropic Docs: [link](https://docs.anthropic.com/en/api/messages)

--- a/docs/llm/deepseek.md
+++ b/docs/llm/deepseek.md
@@ -47,7 +47,7 @@ In addition to the generic options, the following options are Deepseek-specific 
 
 | Option           | Type    | Default     | Description                                                    |
 | ---------------- | ------- | ----------- | -------------------------------------------------------------- |
-| model            | string  | gpt-4o-mini | The model to use. Can be any valid chat model. See Deepseek Docs |
+| model            | string  | deepseek-chat | The model to use. Can be any valid chat model. See Deepseek Docs |
 | deepseekApiKey     | string  | undefined   | API key for Deepseek. See [authentication](/llm/deepseek#authentication)   |
 | temperature      | number  | undefined   | Maps to temperature.*                          |
 | maxTokens        | number  | undefined   | Maps to max_tokens. See Deepseek Docs                            |

--- a/docs/llm/generic.md
+++ b/docs/llm/generic.md
@@ -12,7 +12,7 @@ llm-exe attempts to normalize the inputs for various llm vendors, providing a si
 | jitter        | "none" \| "full" | none    | Used for retry back-off.                                                                                   |
 | temperature   | number           | 0       | Used by model.                                                                                             |
 | maxTokens     | number           | 500     | Used by model.                                                                                             |
-| stream        | boolean \| null  | null    | Note: Not supported 
+| stream        | boolean \| null  | null    | Note: Not supported yet.                                                                                   |
 
 > [!NOTE]
 > Different vendors will allow (and may require) additional options.

--- a/docs/llm/ollama.md
+++ b/docs/llm/ollama.md
@@ -41,7 +41,7 @@ In addition to the generic options, the following options are Ollama-specific an
 
 | Option           | Type    | Default     | Description                                                    |
 | ---------------- | ------- | ----------- | -------------------------------------------------------------- |
-| model            | string  | gpt-4o-mini | The model to use. Can be any valid chat model. See Ollama Docs |
+| model            | string  | —           | The model to use. Must be specified. See Ollama Docs             |
 | temperature      | number  | undefined   | Maps to temperature.*                          |
 | maxTokens        | number  | undefined   | Maps to max_tokens. See Ollama Docs                            |
 | topP             | number  | undefined   | Maps to top_p. See Ollama Docs                                 |

--- a/docs/llm/xai.md
+++ b/docs/llm/xai.md
@@ -44,7 +44,7 @@ In addition to the generic options, the following options are xAI-specific and c
 
 | Option           | Type    | Default     | Description                                                 |
 | ---------------- | ------- | ----------- | ----------------------------------------------------------- |
-| model            | string  | gpt-4o-mini | The model to use. Can be any valid chat model. See xAI Docs |
+| model            | string  | —           | The model to use. Must be specified. See xAI Docs               |
 | xAiApiKey        | string  | undefined   | API key for xAI.                                            |
 | temperature      | number  | undefined   | Maps to temperature.\*                                      |
 | maxTokens        | number  | undefined   | Maps to max_tokens. See xAI Docs                            |

--- a/docs/parser/included-parsers.md
+++ b/docs/parser/included-parsers.md
@@ -20,6 +20,50 @@ This is an example input message.
 
 :::
 
+## Number Parser
+
+`number`
+Extracts a number from the LLM response.
+Returns: number
+
+```ts
+const parser = createParser("number");
+```
+
+::: code-group
+
+```[Parser Output]
+42
+```
+
+```[LLM Response]
+The answer is 42.
+```
+
+:::
+
+## Boolean Parser
+
+`boolean`
+Parses a boolean value from the LLM response. Recognizes common truthy/falsy patterns like "true", "false", "yes", "no".
+Returns: boolean
+
+```ts
+const parser = createParser("boolean");
+```
+
+::: code-group
+
+```[Parser Output]
+true
+```
+
+```[LLM Response]
+Yes, that is correct.
+```
+
+:::
+
 ## String Extractor Parser
 
 `stringExtract`
@@ -86,7 +130,7 @@ const parser = createParser("listToArray");
 ## List to Key/Value[]
 
 `listToKeyValue`
-Converts a
+Converts a list of `key: value` pairs (separated by newlines) to an array of key/value objects.
 Returns Array<{ key: string; value: string; }>
 
 ::: code-group

--- a/docs/parser/index.md
+++ b/docs/parser/index.md
@@ -55,7 +55,7 @@ const parsed = parser.parse(exampleOutputFromLlm);
 When instructing the LLM to respond with json or a format that can be parsed to json, it can be helpful to define schema. This allows you to validate, provide default values, and have a fully-typed response. In fact, the JSON Schema you define can be really useful (and re-used!) in your prompt. [See tips](/examples/concepts/working-with-json) for working with JSON.
 
 ```ts
-import { utils, createParser } from "unnamed-package";
+import { utils, createParser } from "llm-exe";
 
 const schema = utils.defineSchema({
   type: "object",

--- a/docs/prompt/text.md
+++ b/docs/prompt/text.md
@@ -1,5 +1,5 @@
 # Text Prompt
-The default prompt is a text prompt, and is meant for models such as xx and xx. 
+The text prompt returns a single formatted string, useful for simple completion-style prompts or when you need the prompt as a plain string rather than structured chat messages.
 
 You create a prompt using `createPrompt()`.
 

--- a/docs/state/index.md
+++ b/docs/state/index.md
@@ -11,8 +11,9 @@ The state module consists of 3 concepts:
 
 Dialogues are a place to store conversation history, internal dialogues, really any conversation that is taking place with an LLM. You can have one or many dialogues. When you create a new dialogue, you should provide a key, which allows you to access the dialogue from the state later if needed.
 
-TODO:
-Describe Context & Attributes. In summary, attributes are meant to be a basic object, context can more robust classes.
+**Context** items are instances of `BaseStateItem` — typed classes with `getValue()`, `setValue()`, and `resetValue()` methods. Use context for structured, typed data that needs its own lifecycle (e.g., extracted entities, session config). Create context items with `createStateItem(name, defaultValue)` and add them via `state.createContextItem(item)`.
+
+**Attributes** are a simple key-value store for lightweight metadata. Use `state.setAttribute(key, value)`, `state.deleteAttribute(key)`, and `state.clearAttributes()`.
 
 State has a `saveState()` method that can be customized to save the state to a database.
 


### PR DESCRIPTION
## Summary
- Fixed Anthropic docs link that pointed to OpenAI URL
- Fixed both embedding pages referencing the wrong API endpoint (`chat/completions` instead of embeddings)
- Fixed copy-paste model defaults (`gpt-4o-mini`) in Deepseek, Ollama, and xAI provider docs
- Updated intro page from deprecated OpenAI SDK v3 to current v4 API
- Replaced `"unnamed-package"` placeholder with `"llm-exe"` in parser docs
- Added missing `number` and `boolean` parser documentation to included-parsers page
- Fixed truncated `listToKeyValue` description and broken table row in generic.md
- Filled in placeholder text in text prompt page and state TODO section
- Fixed extract example calling `identifyIntent()` instead of `extractInformation()`
- Completed embeddings custom providers section

## Test plan
- [ ] Verify VitePress docs build successfully
- [ ] Spot-check corrected URLs resolve properly
- [ ] Review parser examples render correctly