### PR TITLE
docs: fix JSDoc copy-paste errors in parser and prompt

### DIFF
--- a/src/parser/_functions.ts
+++ b/src/parser/_functions.ts
@@ -66,7 +66,7 @@ export type ParserMap<S extends JSONSchema | undefined = undefined> = {
  * Creates a parser based on the given type.
  * @template S - JSON schema type.
  * @param type - The type of parser to create.
- * @returns An instance of ListToKeyValueParser.
+ * @returns An instance of MarkdownCodeBlocksParser.
  */
 export function createParser<
   T extends Extract<CreateParserType, "markdownCodeBlocks">,
@@ -76,7 +76,7 @@ export function createParser<
  * Creates a parser based on the given type.
  * @template S - JSON schema type.
  * @param type - The type of parser to create.
- * @returns An instance of ListToKeyValueParser.
+ * @returns An instance of MarkdownCodeBlockParser.
  */
 export function createParser<
   T extends Extract<CreateParserType, "markdownCodeBlock">,

--- a/src/prompt/chat.ts
+++ b/src/prompt/chat.ts
@@ -151,7 +151,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
   }
 
   /**
-   * addFunctionMessage Helper to add an assistant message to the prompt.
+   * addFunctionMessage Helper to add a function message to the prompt.
    * @param content The message content.
    * @return ChatPrompt so it can be chained.
    */
@@ -169,7 +169,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
     return this;
   }
   /**
-   * addFunctionCallMessage Helper to add an assistant message to the prompt.
+   * addFunctionCallMessage Helper to add a function_call message to the prompt.
    * @param content The message content.
    * @return ChatPrompt so it can be chained.
    */


### PR DESCRIPTION
## Description

Fix JSDoc copy-paste errors identified in issue #199.

### Changes

**src/parser/_functions.ts:**
- `markdownCodeBlocks` overload: @returns → MarkdownCodeBlocksParser
- `markdownCodeBlock` overload: @returns → MarkdownCodeBlockParser

**src/prompt/chat.ts:**
- `addFunctionMessage`: Helper to add a function message
- `addFunctionCallMessage`: Helper to add a function_call message

## Related Issue
Closes #199

## Checklist
- [x] Documentation-only changes
- [x] No breaking changes
- [x] JSDoc matches implementation