### PR TITLE
fix: bug parseusertemplates defaults to true but comment says it 

### DIFF
--- a/src/prompt/chat.ts
+++ b/src/prompt/chat.ts
@@ -37,7 +37,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
    * user messages with the template engine. This could be a risk,
    * so we only parse user messages if explicitly set.
    */
-  private parseUserTemplates = true;
+  private parseUserTemplates = false;
 
   /**
    * new `ChatPrompt`


### PR DESCRIPTION
## Summary

Closes #200

## Problem

## Description
In `src/prompt/chat.ts:40`, the property `parseUserTemplates` defaults to `true`. But the comment above it states:
> "Whether or not to allow parsing user messages with the template engine. This could be a risk, so we only parse user messages if explicitly set."

## Changes

This PR addresses the issue by:
- Identifying the root cause in the relevant code path
- Applying a targeted fix with minimal scope

## Testing

- [x] Code compiles without errors
- [x] Changes are scoped to the affected code paths only
- [x] Reviewed for regressions and side effects
- [x] Existing test suite verified

## Checklist

- [x] I have read and followed the contribution guidelines
- [x] My changes do not introduce new warnings or errors
- [x] I have commented my code where necessary
