### PR TITLE
fix: warn on hook errors instead of silently swallowing (closes #183)

### DIFF
--- a/scripts/agents/logs/coder/2026-03-09T08-57-25.md
+++ b/scripts/agents/logs/coder/2026-03-09T08-57-25.md
@@ -1,0 +1,20 @@
+# coder agent — 2026:03:09T08:57:25
+
+- **Branch**: agent/coder/2026-03-09
+- **Started**: 2026-03-09T08:57:25Z
+- **Finished**: 2026-03-09T09:02:00Z
+- **Status**: complete
+
+## Summary
+- Fixed issue #183: Hook errors in `BaseExecutor.runHook()` were silently swallowed
+- Added `console.warn` to the catch block so hook errors are logged with the hook name and error object
+- Added 3 tests covering onSuccess, onError, and onComplete hook error warning behavior
+- Executor behavior is unchanged — hook errors still don't propagate, but they're now visible
+
+## Files Changed
+- `src/executor/_base.ts` — replaced empty catch with `console.warn`
+- `src/executor/_base.test.ts` — added 3 tests for hook error warning
+
+## Next Steps
+- Pre-existing lint errors in `src/utils/modules/pick.ts` (no-prototype-builtins) — not related to this change
+- Known issue from CLAUDE.md: Worker process force exit warning in test suite (timer leak in asyncCallWithTimeout.test.ts)

--- a/src/executor/_base.test.ts
+++ b/src/executor/_base.test.ts
@@ -323,6 +323,64 @@ describe("llm-exe:executor/BaseExecutor", () => {
       expect(results.filter(r => r === "new hook")).toHaveLength(1);
     });
 
+    it("should warn when a hook throws an error", async () => {
+      const executor = new MockExecutor();
+      const hookError = new Error("hook failed");
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      executor.on("onSuccess", () => {
+        throw hookError;
+      });
+
+      const result = await executor.execute({ input: "test" });
+
+      expect(result).toEqual({ result: "Success" });
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[llm-exe] Error in "onSuccess" hook:',
+        hookError
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("should warn when onError hook throws an error", async () => {
+      const executor = new MockExecutorThatThrows();
+      const hookError = new Error("onError hook failed");
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      executor.on("onError", () => {
+        throw hookError;
+      });
+
+      await expect(executor.execute({})).rejects.toThrow("Something happened");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[llm-exe] Error in "onError" hook:',
+        hookError
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("should warn when onComplete hook throws an error", async () => {
+      const executor = new MockExecutor();
+      const hookError = new Error("onComplete hook failed");
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      executor.on("onComplete", () => {
+        throw hookError;
+      });
+
+      await executor.execute({ input: "test" });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[llm-exe] Error in "onComplete" hook:',
+        hookError
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it("should properly handle once wrapper removal", async () => {
       const executor = new MockExecutor();
       let callCount = 0;

--- a/src/executor/_base.ts
+++ b/src/executor/_base.ts
@@ -180,7 +180,10 @@ export abstract class BaseExecutor<
         try {
           hookFn(_metadata, this.getMetadata());
         } catch (error) {
-          /** TODO: We should call an error handler */
+          console.warn(
+            `[llm-exe] Error in "${String(hook)}" hook:`,
+            error
+          );
         }
       }
     }


### PR DESCRIPTION
Fixes #183

## Changes
- Replaced empty catch block in BaseExecutor.runHook() with console.warn
- Hook errors still don't propagate but are now visible

## Testing
- Added tests for hook error handling across onSuccess, onError, onComplete