### PR TITLE
fix: improve timeout error message to include duration (closes #178)

### DIFF
--- a/src/utils/modules/asyncCallWithTimeout.test.ts
+++ b/src/utils/modules/asyncCallWithTimeout.test.ts
@@ -32,7 +32,7 @@ describe("asyncCallWithTimeout", () => {
     const resultPromise = asyncCallWithTimeout(asyncPromise, 1000);
     jest.advanceTimersByTime(1000);
     await expect(resultPromise).rejects.toThrow(
-      "Unable to perform action. Try again, or use another action."
+      "LLM call timed out after 1000ms"
     );
   });
 
@@ -93,7 +93,21 @@ describe("asyncCallWithTimeout", () => {
     const resultPromise = asyncCallWithTimeout(asyncPromise);
     jest.advanceTimersByTime(10000);
     await expect(resultPromise).rejects.toThrow(
-      "Unable to perform action. Try again, or use another action."
+      "LLM call timed out after 10000ms"
+    );
+  });
+
+  it("should include the timeout duration in the error message", async () => {
+    const asyncPromise = new Promise<number>((resolve) => {
+      setTimeout(() => {
+        resolve(42);
+      }, 6000);
+    });
+
+    const resultPromise = asyncCallWithTimeout(asyncPromise, 5000);
+    jest.advanceTimersByTime(5000);
+    await expect(resultPromise).rejects.toThrow(
+      "LLM call timed out after 5000ms"
     );
   });
 

--- a/src/utils/modules/asyncCallWithTimeout.ts
+++ b/src/utils/modules/asyncCallWithTimeout.ts
@@ -7,7 +7,7 @@ export const asyncCallWithTimeout = async <T = any>(
   const timeoutPromise = new Promise((_resolve, reject) => {
     timeoutHandle = setTimeout(() => {
       return reject(
-        new Error("Unable to perform action. Try again, or use another action.")
+        new Error(`LLM call timed out after ${timeLimit}ms`)
       );
     }, timeLimit);
   });


### PR DESCRIPTION
## Summary
- Improves the timeout error message to include the configured duration, making it easier to debug timeout issues

## Test plan
- [x] Existing tests updated to verify new error message format