### PR TITLE
fix: preserve system→user→assistant order in setMessageTurn

### DIFF
--- a/src/state/dialogue.test.ts
+++ b/src/state/dialogue.test.ts
@@ -468,10 +468,10 @@ describe("llm-exe:state/Dialogue", () => {
       dialogue.setMessageTurn("User msg", "Assistant msg", "System msg");
       const history = dialogue.getHistory();
       expect(history).toHaveLength(3);
-      expect(history[0].content).toEqual("User msg");
-      expect(history[1].content).toEqual("Assistant msg");
-      expect(history[2].content).toEqual("System msg");
-      expect(history[2].role).toEqual("system");
+      expect(history[0].content).toEqual("System msg");
+      expect(history[0].role).toEqual("system");
+      expect(history[1].content).toEqual("User msg");
+      expect(history[2].content).toEqual("Assistant msg");
     });
 
     it("does not set function message with empty content", () => {

--- a/src/state/dialogue.ts
+++ b/src/state/dialogue.ts
@@ -137,9 +137,9 @@ export class Dialogue extends BaseStateItem<IChatMessages> {
     assistantMessage: string,
     systemMessage: string = ""
   ) {
+    this.setSystemMessage(systemMessage);
     this.setUserMessage(userMessage);
     this.setAssistantMessage(assistantMessage);
-    this.setSystemMessage(systemMessage);
     return this;
   }
 


### PR DESCRIPTION
## Bug
Fixes #294 — `Dialogue.setMessageTurn()` appended the system message after the assistant message, producing an invalid turn order for APIs that expect system context first.

## Fix
- Call `setSystemMessage()` before `setUserMessage()` and `setAssistantMessage()` in `setMessageTurn()`.
- Update the existing regression test to assert the correct `system -> user -> assistant` order.

## Testing
- Ran: `npm test -- --runInBand src/state/dialogue.test.ts`
- Verified updated `setMessageTurn with system message` expectation passes.

Happy to address any feedback.

Greetings, saschabuehrle
