### PR TITLE
fix: allow setValue when initialValue is undefined (#422)

### DIFF
--- a/src/state/item.ts
+++ b/src/state/item.ts
@@ -12,11 +12,14 @@ export abstract class BaseStateItem<T> implements Serializable {
     this.initialValue = initialValue;
   }
   setValue(value: T) {
-    assert(
-      typeof value === typeof this.value,
-      `Invalid value type. Expected ${typeof this
-        .value}, received ${typeof value}`
-    );
+    // When initial value is undefined, any type is acceptable
+    if (this.initialValue !== undefined) {
+      assert(
+        typeof value === typeof this.value,
+        `Invalid value type. Expected ${typeof this
+          .value}, received ${typeof value}`
+      );
+    }
     this.value = value;
   }
   getKey() {


### PR DESCRIPTION
## Fix for #422

### Problem
When `createStateItem` is called without a meaningful default value (e.g., `undefined`), calling `setValue()` later fails with:
```
Invalid value type. Expected undefined, received string
```

### Solution
Skip the type check when `initialValue` is `undefined`, allowing any type to be set.

### Changes
- `src/state/item.ts`: Added check for `this.initialValue !== undefined` before type assertion

---

_This PR was submitted as part of the GitHub Bounty Automation project._