### PR TITLE
Add workflow to update open PRs targeting development

### DIFF
--- a/.github/workflows/update-prs-with-development.yml
+++ b/.github/workflows/update-prs-with-development.yml
@@ -1,0 +1,49 @@
+name: Update Open PRs with Development
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5"  # Weekdays 8am UTC (3am CT)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Update open PRs targeting development
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          PR_NUMBERS=$(gh pr list --base development --state open --json number --jq '.[].number')
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open PRs targeting development."
+            exit 0
+          fi
+
+          for PR in $PR_NUMBERS; do
+            echo "Attempting to update PR #$PR..."
+            if gh pr update-branch "$PR" 2>&1; then
+              echo "PR #$PR updated successfully."
+            else
+              echo "PR #$PR skipped (conflicts or already up to date)."
+            fi
+          done


### PR DESCRIPTION
# Description

This update introduces a scheduled workflow that automatically updates open pull requests targeting the development branch. The workflow runs on weekdays at 8 AM UTC and can also be triggered manually.

# Testing

The workflow has been tested to ensure it correctly identifies and updates open PRs. Results show successful updates or appropriate messages for PRs that are already up to date or have conflicts.