### PR TITLE
Add full_refresh option to docs-sync workflow and improve automations

### DIFF
--- a/.github/workflows/agent-review-pr.yml
+++ b/.github/workflows/agent-review-pr.yml
@@ -2,7 +2,11 @@ name: Agent Review PR
 
 on:
   pull_request:
-    types: [opened]
+    # opened   - initial PR creation (runs tests + review + decide)
+    # synchronize - new commits pushed / rebase from update-prs-with-development
+    #              (runs tests only; review is gated to opened so the agent
+    #               does not re-review on every rebase)
+    types: [opened, synchronize]
     branches: [main, development]
 
 permissions:
@@ -43,8 +47,9 @@ jobs:
         run: npm run test
 
   # Runs in parallel with tests. Exposes verdict as a job output for decide.
+  # Gated to opened only — no point re-reviewing on synchronize (rebase) events.
   review:
-    if: github.base_ref == 'development'
+    if: github.base_ref == 'development' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -169,12 +174,19 @@ jobs:
               --body "Approved by reviewer agent (tests passing)." \
               --repo ${{ github.repository }}
 
-            IS_DRAFT=$(gh pr view ${{ github.event.pull_request.number }} \
-              --json isDraft --jq '.isDraft' \
-              --repo ${{ github.repository }})
-            if [ "$IS_DRAFT" = "true" ]; then
-              GH_TOKEN="$BOT_TOKEN" gh pr ready ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
-              echo "PR marked as ready for review."
+            # Only promote draft -> ready for agent-opened PRs (branch prefix agent/).
+            # Human PRs stay in whatever draft state the author left them in.
+            head_ref="${{ github.event.pull_request.head.ref }}"
+            if echo "$head_ref" | grep -q '^agent/'; then
+              IS_DRAFT=$(gh pr view ${{ github.event.pull_request.number }} \
+                --json isDraft --jq '.isDraft' \
+                --repo ${{ github.repository }})
+              if [ "$IS_DRAFT" = "true" ]; then
+                GH_TOKEN="$BOT_TOKEN" gh pr ready ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+                echo "PR marked as ready for review."
+              fi
+            else
+              echo "Human PR (branch: $head_ref) — skipping gh pr ready."
             fi
 
             echo "PR #${{ github.event.pull_request.number }} approved."

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -162,7 +162,7 @@ jobs:
             Read the file /tmp/agent-prompt.txt for your full instructions. Follow them exactly.
           claude_args: |
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebFetch"
-            --max-turns 50
+            --max-turns 80
             --model claude-opus-4-6
 
       - name: Upload agent prompt

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -15,6 +15,11 @@ on:
         description: "Comma-separated paths to sync docs for. Leave empty to diff HEAD against its parent."
         required: false
         type: string
+      full_refresh:
+        description: "Refresh ALL docs regardless of recent changes. Overrides target."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: docs-sync
@@ -67,8 +72,22 @@ jobs:
       - name: Detect changed files
         id: detect
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.target }}" ]; then
+          if [ "${{ inputs.full_refresh }}" = "true" ]; then
+            # Full-refresh mode: list every tracked source file so the agent
+            # audits all deep dives for drift, not just recently changed ones.
+            {
+              find .github/workflows -maxdepth 1 -name '*.yml' | sort
+              find .github/actions   -name '*.yml'              | sort
+              find .github/vitals    -type f                     | sort
+              echo scripts/maintain.sh
+              echo scripts/agents/config.sh
+              find scripts/agents/prompts -type f               | sort
+              echo package.json
+            } | grep -v '^$' > /tmp/changed-files.txt
+
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.target }}" ]; then
             echo "${{ inputs.target }}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' > /tmp/changed-files.txt
+
           else
             base="${{ github.event.before }}"
             if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -143,7 +143,7 @@ jobs:
           Run \`date -u +%H:%M\` periodically to check how much time you have left.
           If you're running low on time, commit what you have, update your log file, and stop. A partial result is better than getting killed mid-work.
 
-          ## Changed Source Files
+          ## Changed Source Files 
           The following files changed in the triggering commit range. Map each to the affected deep-dive(s) using the table in your prompt, then update those docs:
 
           $(cat /tmp/changed-files.txt)"


### PR DESCRIPTION
# Description

This pull request updates two GitHub Actions workflows: `agent-review-pr.yml` and `docs-sync.yml`. The main improvements are to make the agent review workflow more robust to rebases and to add a full-refresh option for the docs sync workflow, allowing all documentation to be audited regardless of recent changes.

**Agent Review Workflow Improvements:**

* The workflow now triggers on both `opened` and `synchronize` (e.g., rebases or new commits) events, ensuring tests always run for new commits, but agent review only runs on initial PR creation to avoid redundant reviews.
* The `review` job is further gated to only run on `opened` events, preventing unnecessary re-reviews on every rebase or commit.
* The workflow now only promotes draft PRs to ready for review if the branch name starts with `agent/`, ensuring that only agent-created PRs are auto-promoted, while human PRs retain their intended draft state.

**Docs Sync Workflow Enhancements:**

* Added a `full_refresh` input option to the workflow, allowing a manual trigger to audit all documentation files, not just those recently changed.
* When `full_refresh` is enabled, the workflow collects every relevant tracked documentation source file for auditing, rather than just the files changed in the current commit or target.

# Testing


# Reviewers

