### PR TITLE
Enhance workflow for agent review PRs

### DIFF
--- a/.github/workflows/agent-review-pr.yml
+++ b/.github/workflows/agent-review-pr.yml
@@ -9,6 +9,22 @@ on:
     types: [opened, synchronize]
     branches: [main, development]
 
+  # Dispatched by bot-respond.yml when a maintainer comments "@llm-exe-bot re-review"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
+      base_ref:
+        description: "Base branch of the PR (e.g. development)"
+        required: true
+        type: string
+      head_ref:
+        description: "Head branch of the PR"
+        required: true
+        type: string
+
 permissions:
   contents: read
   pull-requests: write
@@ -20,7 +36,7 @@ jobs:
   # Mirrors tests.yml exactly (matrix, cache action, npm install, npm run test).
   # Coverage upload is intentionally omitted — that is tests.yml's responsibility on main PRs.
   tests:
-    if: github.base_ref == 'development'
+    if: github.base_ref == 'development' || (github.event_name == 'workflow_dispatch' && inputs.base_ref == 'development')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -49,7 +65,7 @@ jobs:
   # Runs in parallel with tests. Exposes verdict as a job output for decide.
   # Gated to opened only — no point re-reviewing on synchronize (rebase) events.
   review:
-    if: github.base_ref == 'development' && github.event.action == 'opened'
+    if: (github.base_ref == 'development' && github.event.action == 'opened') || (github.event_name == 'workflow_dispatch' && inputs.base_ref == 'development')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -82,9 +98,9 @@ jobs:
         id: prompt
         run: |
           source ./scripts/agents/config.sh
-          log_file=$(clock_in "reviewer" "PR #${{ github.event.pull_request.number }}")
+          log_file=$(clock_in "reviewer" "PR #${{ github.event.pull_request.number || inputs.pr_number }}")
 
-          head_ref="${{ github.event.pull_request.head.ref }}"
+          head_ref="${{ github.event.pull_request.head.ref || inputs.head_ref }}"
           if echo "$head_ref" | grep -q '^agent/'; then
             pr_context="This PR was opened by a bot agent (branch: ${head_ref}). It is automated code - hold it to the same standards but be aware it may follow mechanical patterns."
           else
@@ -92,7 +108,7 @@ jobs:
           fi
 
           prompt=$(sed \
-            -e "s|\$PR_NUMBER|${{ github.event.pull_request.number }}|g" \
+            -e "s|\$PR_NUMBER|${{ github.event.pull_request.number || inputs.pr_number }}|g" \
             -e "s|\$LOG_FILE|$log_file|g" \
             -e "s|\$PR_CONTEXT|${pr_context}|g" \
             ./scripts/agents/prompts/reviewer.md)
@@ -145,7 +161,7 @@ jobs:
   #   ("Resource not accessible by integration" error).
   decide:
     needs: [tests, review]
-    if: always() && github.base_ref == 'development'
+    if: always() && (github.base_ref == 'development' || (github.event_name == 'workflow_dispatch' && inputs.base_ref == 'development'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -169,27 +185,27 @@ jobs:
           echo "Tests result   : $tests_result"
 
           if [ "$verdict" = "approve" ] && [ "$tests_result" = "success" ]; then
-            gh pr review ${{ github.event.pull_request.number }} \
+            gh pr review ${{ github.event.pull_request.number || inputs.pr_number }} \
               --approve \
               --body "Approved by reviewer agent (tests passing)." \
               --repo ${{ github.repository }}
 
             # Only promote draft -> ready for agent-opened PRs (branch prefix agent/).
             # Human PRs stay in whatever draft state the author left them in.
-            head_ref="${{ github.event.pull_request.head.ref }}"
+            head_ref="${{ github.event.pull_request.head.ref || inputs.head_ref }}"
             if echo "$head_ref" | grep -q '^agent/'; then
-              IS_DRAFT=$(gh pr view ${{ github.event.pull_request.number }} \
+              IS_DRAFT=$(gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} \
                 --json isDraft --jq '.isDraft' \
                 --repo ${{ github.repository }})
               if [ "$IS_DRAFT" = "true" ]; then
-                GH_TOKEN="$BOT_TOKEN" gh pr ready ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+                GH_TOKEN="$BOT_TOKEN" gh pr ready ${{ github.event.pull_request.number || inputs.pr_number }} --repo ${{ github.repository }}
                 echo "PR marked as ready for review."
               fi
             else
               echo "Human PR (branch: $head_ref) — skipping gh pr ready."
             fi
 
-            echo "PR #${{ github.event.pull_request.number }} approved."
+            echo "PR #${{ github.event.pull_request.number || inputs.pr_number }} approved."
           else
             echo "No approval submitted: verdict='$verdict', tests='$tests_result'."
           fi

--- a/.github/workflows/agent-review-pr.yml
+++ b/.github/workflows/agent-review-pr.yml
@@ -47,6 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout PR (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: gh pr checkout ${{ inputs.pr_number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/bot-respond.yml
+++ b/.github/workflows/bot-respond.yml
@@ -63,16 +63,30 @@ jobs:
 
             ## Determine what's being asked
 
-            Read the comment that mentioned you carefully. You can be asked to do two kinds of things:
+            Read the comment that mentioned you carefully. Decide which of the following applies:
 
-            ### 1. Answer questions or review (read-only)
-            If the maintainer is asking a question, requesting a review, or wants your opinion:
+            ### 1. PR review requested
+            If the maintainer wants you to review a pull request — any phrasing like "review this", "re-review", "take another look", "check the PR", "can you review", etc. — AND the comment is on a pull request:
+            - Fetch the PR's base and head branch:
+              `gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json baseRefName,headRefName`
+            - Dispatch the review pipeline (do NOT do an inline review yourself):
+              `gh workflow run agent-review-pr.yml \
+                --repo ${{ github.repository }} \
+                -f pr_number="${{ github.event.issue.number }}" \
+                -f base_ref="<base_ref from above>" \
+                -f head_ref="<head_ref from above>"`
+            - Post a brief acknowledgment, e.g.:
+              "👀 Review pipeline started — tests + agent review + approval will run shortly."
+            - Stop here. Do not also do a manual review.
+
+            ### 2. Answer questions (read-only)
+            If the maintainer is asking a question or wants your opinion on something:
             - Read any relevant source code
             - Use `gh pr diff` or `gh pr view` to understand PR context
             - Run `npm test` and `npm run typecheck` if needed to verify things
             - Reply with a concise, specific answer
 
-            ### 2. Make changes (write mode)
+            ### 3. Make changes (write mode)
             If the maintainer is asking you to fix something, revise a PR, address review feedback, or make code changes:
             - If you're on a PR, check out the PR branch: `gh pr checkout <number>`
             - Read the PR diff, review comments, and any feedback with:


### PR DESCRIPTION
# Description

This pull request updates the `agent-review-pr.yml` workflow to allow maintainers to manually trigger a full review pipeline (tests, agent review, and approval) on any pull request using a workflow dispatch event. It also improves the instructions in `bot-respond.yml` to clarify how the bot should respond when asked to review a PR. The main changes ensure that the review pipeline can be re-run on demand and that all relevant jobs and steps work correctly when triggered manually.

**Workflow dispatch support for manual PR review:**

* Added a `workflow_dispatch` trigger to `.github/workflows/agent-review-pr.yml` with required inputs for `pr_number`, `base_ref`, and `head_ref`, allowing maintainers to manually trigger the review pipeline for any PR.
* Updated job conditions (`if` clauses) in the `tests`, `review`, and `decide` jobs to support both standard PR events and manual workflow dispatch, ensuring the pipeline runs only for PRs targeting the `development` branch. [[1]](diffhunk://#diff-6496af60cfb4384eb0264ec3e85ba38d4bc94beeaf8477eac58b9c9eebf04a28L23-R39) [[2]](diffhunk://#diff-6496af60cfb4384eb0264ec3e85ba38d4bc94beeaf8477eac58b9c9eebf04a28L52-R74) [[3]](diffhunk://#diff-6496af60cfb4384eb0264ec3e85ba38d4bc94beeaf8477eac58b9c9eebf04a28L148-R170)
* Added a step to check out the correct PR branch when the workflow is triggered via `workflow_dispatch`.
* Modified shell scripts and references throughout the workflow to use either the standard PR event fields or the workflow dispatch inputs, ensuring correct PR context and actions regardless of how the workflow is triggered. [[1]](diffhunk://#diff-6496af60cfb4384eb0264ec3e85ba38d4bc94beeaf8477eac58b9c9eebf04a28L85-R117) [[2]](diffhunk://#diff-6496af60cfb4384eb0264ec3e85ba38d4bc94beeaf8477eac58b9c9eebf04a28L172-R214)

**Bot instruction improvements:**

* Updated the bot's response instructions in `bot-respond.yml` to clearly distinguish between review requests and other types of requests, and to provide explicit steps for dispatching the review workflow instead of doing an inline review.

# Testing

Tested the new workflow inputs and bot responses to ensure they function as intended.

# Reviewers

@reviewer_username

