### PR TITLE
Fix release notes cleaning to exclude 'docs: sync' commits

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -89,8 +89,8 @@ jobs:
     - name: Clean up release notes
       id: clean_release_notes
       run: |
-        # Remove automation-related commits (chore: bump version, Draft PR for release, Bump Version on PR to Main) and remove "by @username in" from PR references
-        CLEANED_BODY=$(sed '/chore: bump version/Id; /Draft PR for release/Id; /Bump Version on PR to Main/Id' release_body.txt | sed -E 's/ by @[^ ]+ in/ /g')
+        # Remove automation-related commits (chore: bump version, Draft PR for release, Bump Version on PR to Main, docs: sync) and remove "by @username in" from PR references
+        CLEANED_BODY=$(sed '/chore: bump version/Id; /Draft PR for release/Id; /Bump Version on PR to Main/Id; /docs: sync/Id' release_body.txt | sed -E 's/ by @[^ ]+ in/ /g')
         echo "$CLEANED_BODY" > cleaned_body.txt
         echo "📝 Cleaned release notes:"
         cat cleaned_body.txt


### PR DESCRIPTION
# Description

Update the release notes cleaning process to exclude commits labeled as 'docs: sync' along with other automation-related commits.

# Testing

Tested the release notes cleaning process to ensure that 'docs: sync' commits are no longer included in the cleaned output.

# Reviewers

@reviewer_username

