### PR TITLE
Increase max turns from 30 to 50 in bot config

### DIFF
--- a/.github/workflows/bot-respond.yml
+++ b/.github/workflows/bot-respond.yml
@@ -109,5 +109,5 @@ jobs:
             - Be conversational and concise. Reference actual code (file paths, line numbers) when relevant.
           claude_args: |
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
-            --max-turns 30
+            --max-turns 50
             --model ${{ vars.ANTHROPIC_OPUS_LATEST || 'claude-opus-4-6' }}


### PR DESCRIPTION
# Description

A description of what is being added or changed. If bug, reference the bug link. Add screenshots/short videos where applicable

This pull request makes a small configuration change to the bot response workflow. The maximum number of conversational turns allowed for the bot has been increased from 30 to 50.

* Increased the `--max-turns` argument from 30 to 50 in the `.github/workflows/bot-respond.yml` file, allowing the bot to engage in longer conversations.
* 
# Testing

What testing was done and what are the results. Add screenshots/short videos where applicable

# Reviewers

@mentions of 1 person at minimum to review the proposed changes