### PR TITLE
Adjust new naming of parser match options

### DIFF
--- a/docs/misc/v2-to-v3-migration-guide.md
+++ b/docs/misc/v2-to-v3-migration-guide.md
@@ -108,7 +108,7 @@ See [Error Handling](/misc/errors.html).
 
 ## JSON Parser Is Strict
 
-`createParser("json")` now parses whole-output JSON object or array values.
+`createParser("json")` now parses exact JSON object or array responses by default.
 
 Accepted:
 
@@ -134,7 +134,14 @@ Migration:
 
 - Use `string`, `number`, or `boolean` parsers for primitive outputs.
 - Ask the model for a JSON object or array when using the JSON parser.
-- If the model returns prose around JSON, change the prompt or add an explicit extraction step before the JSON parser.
+- If the model returns prose around JSON, change the prompt or set `match: "extract"`.
+
+```ts
+createParser("json", { match: "extract" }).parse(
+  "Here is JSON:\n```json\n{\"name\":\"Greg\"}\n```"
+);
+// 3.x: { name: "Greg" }
+```
 
 ## JSON Schema Validation Defaults to On
 
@@ -235,14 +242,14 @@ Migration:
 - Keep `json` for strict JSON object/array parsing.
 - Use `validateSchema: false` only when preserving old filter/default-only behavior is intentional.
 
-## Boolean Parser Is Whole-Output Strict
+## Boolean Parser Is Exact by Default
 
 The boolean parser accepts only documented boolean literals after trimming and lowercasing:
 
 - truthy: `true`, `yes`, `y`, `1`
 - falsy: `false`, `no`, `n`, `0`
 
-It does not extract booleans from prose.
+By default, it does not extract booleans from prose.
 
 ```ts
 createParser("boolean").parse("false");
@@ -255,7 +262,12 @@ createParser("boolean").parse("The answer is true.");
 Migration:
 
 - Prompt for only the boolean token.
-- Use a custom parser or preprocessing step if prose extraction is required.
+- Use `match: "extract"` when the model may return prose.
+
+```ts
+createParser("boolean", { match: "extract" }).parse("The answer is true.");
+// 3.x: true
+```
 
 ## stringExtract Defaults Changed
 
@@ -264,6 +276,12 @@ Migration:
 ```ts
 createParser("stringExtract", { enum: ["yes"] }).parse("ayesha");
 // 3.x: throws parser.parse_failed
+
+createParser("stringExtract", {
+  enum: ["yes"],
+  match: "word",
+}).parse("yes please");
+// 3.x: "yes"
 
 createParser("stringExtract", {
   enum: ["yes"],
@@ -276,6 +294,7 @@ Migration:
 
 - Use the default `word` matching for enum extraction from prose.
 - Set `match: "substring"` when preserving legacy contains behavior.
+- Set `match: "exact"` when surrounding text should fail.
 - Set `ignoreCase: false` when case-sensitive matching is required.
 
 ## Number Parser Rejects Ambiguous or Invalid Numeric Text
@@ -293,17 +312,17 @@ createParser("number").parse("1,00,000");
 // 3.x: throws parser.parse_failed
 ```
 
-Use `match: "whole"` to require the entire input to be a numeric token.
+Use `match: "exact"` to require the entire input to be a numeric token.
 
 ```ts
-createParser("number", { match: "whole" }).parse("5 dollars");
+createParser("number", { match: "exact" }).parse("5 dollars");
 // 3.x: throws parser.parse_failed
 ```
 
 Migration:
 
 - Use default extraction for one-number prose.
-- Use `match: "whole"` when surrounding text should fail.
+- Use `match: "exact"` when surrounding text should fail.
 - Clean or normalize non-US comma grouping before parsing if needed.
 
 ## Markdown Code Block Parsers Are Explicit

--- a/docs/parser/included-parsers.md
+++ b/docs/parser/included-parsers.md
@@ -27,12 +27,17 @@ This is an example input message.
 ## Number Parser
 
 `number`
-Extracts a number from the LLM response.
+Extracts exactly one number from the LLM response.
 Returns: number
 
 ```ts
 const parser = createParser("number");
 ```
+
+Options:
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `match` | `"extract" \| "exact"` | `"extract"` | `"extract"` finds one numeric token in the response. `"exact"` requires the entire trimmed response to be one numeric token. |
 
 ::: code-group
 
@@ -56,6 +61,11 @@ Returns: boolean
 const parser = createParser("boolean");
 ```
 
+Options:
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `match` | `"exact" \| "extract"` | `"exact"` | `"exact"` requires the entire trimmed response to be one boolean literal. `"extract"` finds one boolean literal in surrounding text. |
+
 ::: code-group
 
 ```[Output]
@@ -63,7 +73,7 @@ true
 ```
 
 ```[Response]
-Yes, that is correct.
+yes
 ```
 
 :::
@@ -87,7 +97,8 @@ Options:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enum` | `string[]` | `[]` | The list of allowed values to match against. |
-| `ignoreCase` | `boolean` | `false` | When `true`, matching is case-insensitive. |
+| `ignoreCase` | `boolean` | `true` | When `true`, matching is case-insensitive. |
+| `match` | `"word" \| "substring" \| "exact"` | `"word"` | `"word"` matches enum values on word boundaries. `"substring"` uses contains matching. `"exact"` requires the entire trimmed response to equal one enum value. |
 
 ::: code-group
 
@@ -316,7 +327,7 @@ Type: Fruit
 ## JSON
 
 `json`
-Parse an expected stringified json object or array into a valid object. Schema can be passed in to enforce schema and provide default values.
+Parse an expected stringified JSON object or array into a valid object. Schema can be passed in to enforce schema and provide default values.
 Returns: object | array
 
 ```ts
@@ -327,6 +338,7 @@ Options:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `schema` | `JSONSchema` | `undefined` | Optional JSON Schema to validate and enforce types on the output. Use with [`defineSchema`](/parser/index.html#defineschema) for full type inference. |
+| `match` | `"exact" \| "extract"` | `"exact"` | `"exact"` parses the entire response as JSON. `"extract"` finds one JSON object or array in surrounding text. |
 
 ::: code-group
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -18,8 +18,8 @@ import { /* specific modules */ } from "llm-exe"
 ```
 
 ## Basic Example
-Below is simple example:
-```js
+Below is a simple example:
+```ts
 import {
   useLlm,
   createChatPrompt,
@@ -27,38 +27,40 @@ import {
 } from "llm-exe";
 
 const llm = useLlm("openai.gpt-4o-mini");
-const prompt = createChatPrompt("Talk like a pirate.")
+
+// The first argument is the system message.
+// Add a user message that references your input variable.
+const prompt = createChatPrompt<{ input: string }>("Talk like a pirate.")
+  .addUserMessage("{{input}}");
 
 const executor = createLlmExecutor({
   llm,
-  prompt
-})
+  prompt,
+});
 
-const input = "Hello!";
-const response = await executor.execute({ input })
+const response = await executor.execute({ input: "Hello!" });
 /**
- * 
- * The prompt sent to the LLM would be: 
- * (line breaks added for readability)
- * 
- * [{ 
- *   role: 'system', 
- *   content: 'Talk like a pirate.' 
- * },
- * { 
- *   role: 'user',
- *   content: 'Hello!'
- * }]
- * 
+ *
+ * The prompt sent to the LLM would be:
+ *
+ * [
+ *   { role: 'system', content: 'Talk like a pirate.' },
+ *   { role: 'user',   content: 'Hello!' }
+ * ]
+ *
  */
 
 /**
- * 
+ *
  * Output from LLM executor:
- * Arrr, matey! Speak up, fer me ears be as keen as a sea serpent's! 
+ * Arrr, matey! Speak up, fer me ears be as keen as a sea serpent's!
  * Avast ye, what be your query?
- * /
+ */
 ```
+
+::: tip
+Passing a value as `{ input }` does **not** automatically append a user message — your prompt must reference it (for example with `{{input}}` in a template or by calling `.addUserMessage("{{input}}")`). The chat prompt always renders exactly the messages you build.
+:::
 ---
 
 # Introduction
@@ -228,11 +230,11 @@ const response = await piiDetector(input)
  * Output:
  *
  * {
- *   emailAddress: false,
+ *   emailAddresses: false,
  *   socialSecurityNumber: false,
  *   creditCardNumber: true
  * }
- * /
+ */
 ```
 
 The input and output of the `piiDetector` function are strongly typed, providing reliable structure and safety when integrating with the rest of your application
@@ -252,6 +254,58 @@ Note: llm-exe utilizes the underlying API's from the various providers. This mea
 - Automatic retry with configurable back-off for errors.
 - Use different LLM's with different configurations for different functions.
 Note: You can use and call methods on LLM's directly, but they are usually passed to an LLM executor and then called internally.
+
+## Using `useLlm`
+
+The `useLlm` function creates an LLM instance. It takes a provider key and an optional options object.
+
+### Provider Shorthand (by model)
+
+Use a provider-specific model shorthand to get full type support for that model's options:
+
+```ts
+import { useLlm } from "llm-exe";
+
+const llm = useLlm("openai.gpt-4o-mini");
+```
+
+### Provider Key + Model Option
+
+Use a generic provider key and specify the model in the options. This lets you use any model the provider supports without needing a dedicated shorthand:
+
+```ts
+const llm = useLlm("openai.chat.v1", {
+  model: "gpt-4o",
+});
+```
+
+### Options
+
+All providers accept the [generic options](/llm/generic.html) (timeout, retries, temperature, maxTokens, etc.). Each provider may also accept provider-specific options — see the individual provider pages below.
+
+### Deprecation Warnings
+
+Deprecated provider/model shorthands continue to resolve for compatibility, but emit a Node `DeprecationWarning` with code `LLM_EXE_DEPRECATED` on first use. See [Deprecation Warnings](/llm/deprecations.html).
+
+### Authentication
+
+Each provider requires an API key. You can provide it in three ways:
+
+1. **Environment variable** — set the provider's default env var (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+2. **Setup options** — pass the key when creating the LLM (e.g., `{ openAiApiKey: "sk-..." }`)
+3. **Execute options** — pass the key at execution time
+
+See the individual provider pages for the exact option names and env var names.
+
+### Direct Usage
+
+While you'll typically pass the LLM instance to an [executor](/executor/), you can also call it directly:
+
+```ts
+const llm = useLlm("openai.gpt-4o-mini");
+const response = await llm.call(prompt);
+console.log(response.getResultText());
+```
 
 ## Currently Supported Providers
 
@@ -308,6 +362,7 @@ llm-exe attempts to normalize the inputs for various llm vendors, providing a si
 > - [Ollama Chat Model Options](/llm/ollama#ollama-specific-options)
 > - [AWS Bedrock Chat Model Options](/llm/bedrock/index.html)
 
+
 ---
 
 # OpenAI
@@ -352,7 +407,7 @@ await llm.call(prompt);
 
 ## OpenAi-Specific Options
 
-In addition to the generic options, the following options are OpenAi-specific and can be passed in when creating a llm function.
+In addition to the [generic options](/llm/generic.html), the following options are OpenAi-specific and can be passed in when creating a llm function.
 
 | Option           | Type    | Default     | Description                                                    |
 | ---------------- | ------- | ----------- | -------------------------------------------------------------- |
@@ -430,16 +485,16 @@ When using Google Gemini models, llm-exe will make POST requests to `https://gen
 
 ```ts
 const llm = useLlm("google.chat.v1", {
-  model: "gemini-2.0-flash", // specify a model
+  model: "gemini-2.5-flash", // specify a model
 });
 ```
 
 ### Gemini Chat By Model
 
 ```ts
-const llm = useLlm("google.gemini-2.0-flash", {
+const llm = useLlm("google.gemini-2.5-flash", {
   // other options,
-  // no model needed, using gemini-2.0-flash
+  // no model needed, using gemini-2.5-flash
 });
 ```
 
@@ -447,7 +502,7 @@ const llm = useLlm("google.gemini-2.0-flash", {
 
 ## Authentication
 
-To authenticate, you need to provide an Google Gemini API Key. You can provide the API key various ways, depending on your use case.
+To authenticate, you need to provide a Google Gemini API Key. You can provide the API key various ways, depending on your use case.
 
 1. Pass in as execute options using `geminiApiKey`
 2. Pass in as setup options using `geminiApiKey`
@@ -546,8 +601,7 @@ In addition to the [generic options](/llm/generic.html), the following options a
 | awsAccessKey| string | undefined | AWS Access Key. Can be set via `AWS_ACCESS_KEY_ID` environment variable  |
 
 > [!NOTE]
-> The Bedrock Anthropic provider maps a subset of the direct Anthropic provider options. Options like `temperature`, `topK`, `stopSequences`, `metadata`, and `serviceTier` are not mapped for the Bedrock variant at this time.
-
+> The Bedrock Anthropic provider maps a subset of the direct [Anthropic provider](/llm/anthropic.html) options. Options like `temperature`, `topK`, `stopSequences`, `metadata`, and `serviceTier` are not mapped for the Bedrock variant at this time.
 ---
 
 # Meta
@@ -617,6 +671,13 @@ const llm = useLlm("xai.grok-4", {
 });
 ```
 
+```ts
+const llm = useLlm("xai.grok-3-mini", {
+  // other options,
+  // no model needed, using grok-3-mini
+});
+```
+
 <ImportModelNames provider="xai" />
 
 ## Authentication
@@ -678,7 +739,9 @@ const llm = useLlm("ollama.deepseek-r1", {
 
 <ImportModelNames provider="ollama" />
 
+## Configuration
 
+By default, llm-exe connects to `http://localhost:11434`. To use a different Ollama endpoint, set the `OLLAMA_ENDPOINT` environment variable.
 
 Generally you pass the LLM instance off to an LLM Executor and call that. However, it is possible to interact with the LLM object directly, if you wanted.
 
@@ -688,8 +751,6 @@ await llm.call(prompt);
 ```
 
 ## Ollama-Specific Options
-
-In addition to the generic options, the following options are Ollama-specific and can be passed in when creating a llm function.
 
 | Option | Type   | Default   | Description                                                    |
 | ------ | ------ | --------- | -------------------------------------------------------------- |
@@ -705,6 +766,15 @@ See [Ollama Docs](https://ollama.com/) for details.
 # Deepseek
 
 When using Deepseek models, llm-exe will make POST requests to `https://api.deepseek.com/v1/chat/completions`. All models are supported if you pass `deepseek.chat.v1` as the first argument, and then specify a model in the options.
+
+llm-exe ships typed shorthands for the most common Deepseek models so you do not have to remember the exact model strings:
+
+| Shorthand              | Default model        |
+| ---------------------- | -------------------- |
+| `deepseek.chat.v1`     | _none — set `model`_ |
+| `deepseek.chat`        | `deepseek-chat`      |
+| `deepseek.v4-flash`    | `deepseek-v4-flash`  |
+| `deepseek.v4-pro`      | `deepseek-v4-pro`    |
 
 ## Basic Usage
 
@@ -725,11 +795,25 @@ const llm = useLlm("deepseek.chat", {
 });
 ```
 
+```ts
+const llm = useLlm("deepseek.v4-flash", {
+  // other options,
+  // no model needed, using deepseek-v4-flash model
+});
+```
+
+```ts
+const llm = useLlm("deepseek.v4-pro", {
+  // other options,
+  // no model needed, using deepseek-v4-pro model
+});
+```
+
 <ImportModelNames provider="deepseek" />
 
 ## Authentication
 
-To authenticate, you need to provide an Deepseek API Key. You can provide the API key various ways, depending on your use case.
+To authenticate, you need to provide a Deepseek API Key. You can provide the API key various ways, depending on your use case.
 
 1. Pass in as execute options using `deepseekApiKey`
 2. Pass in as setup options using `deepseekApiKey`
@@ -829,7 +913,7 @@ const customLlm = useLlmConfiguration({
 // Use it like any other LLM
 const llm = customLlm({
   apiKey: process.env.CUSTOM_API_KEY,
-  model: "gpt-4-turbo",
+  model: "gpt-4o",
 } as any); // Note: Use 'as any' for custom options that aren't in base types
 
 const response = await llm.call("Hello, how are you?");
@@ -1242,6 +1326,7 @@ See:
 
 - [Text Prompt](/prompt/text.html)
 - [Chat Prompt](/prompt/chat.html)
+- [Prompt Validation](/prompt/validation.html)
 
 ## Basic Replacements
 
@@ -1253,6 +1338,12 @@ The object that you pass to `prompt.format` (or `.execute` when a prompt is part
 </GenericOutput>
 
 For advanced uses and working with custom helpers/partials, [see here](/prompt/advanced.html).
+
+## Validating Template Inputs
+
+Prompts can validate that required template variables and helpers are available before rendering. Use `prompt.validate(input)` directly, or set `validateInput: "strict"` / `"warn"` on a prompt to check calls to `format()`.
+
+See [Prompt Validation](/prompt/validation.html).
 
 ## Using Types with Prompts
 
@@ -1541,6 +1632,33 @@ Website: www.example.com`,
 const prompt = createPrompt("text", "You are a cowboy.", { helpers, partials });
 ```
 
+### 2. Register them globally
+
+If you want helpers or partials available to all prompts in your application, use the standalone `registerHelpers` and `registerPartials` utility functions. These register with the global Handlebars instance, so any prompt created afterward can use them.
+
+```ts
+import { registerHelpers, registerPartials } from "llm-exe";
+
+// Register custom helpers globally
+registerHelpers([
+  {
+    name: "uppercase",
+    handler: (str: string) => str.toUpperCase(),
+  },
+]);
+
+// Register custom partials globally
+registerPartials([
+  {
+    name: "greeting",
+    template: "Hello {{name}}!",
+  },
+]);
+
+// Now any prompt can use them
+const prompt = createChatPrompt("{{> greeting name='World'}} {{uppercase 'hello'}}");
+```
+
 ---
 
 # Why Handlebars?
@@ -1717,8 +1835,8 @@ When combined with an LLM executor, the parser is responsible for providing type
 
 When working with output parsers, you have two options:
 
-1. Use a default parser.
-2. Extend the base parser to create a custom output parser
+1. Use a [default parser](/parser/included-parsers.html).
+2. Create a [custom parser](/parser/custom.html) for full control over output transformation.
 
 #### Use a Default Parser
 
@@ -1749,6 +1867,10 @@ const parsed = parser.parse(exampleOutputFromLlm);
 #### Using a Parser with Schema
 
 When instructing the LLM to respond with json or a format that can be parsed to json, it can be helpful to define schema. This allows you to validate, provide default values, and have a fully-typed response. In fact, the JSON Schema you define can be really useful (and re-used!) in your prompt. [See tips](/examples/concepts/working-with-json) for working with JSON.
+
+##### `defineSchema`
+
+The `defineSchema` helper narrows a JSON Schema definition to its literal type so TypeScript can infer the exact shape of the parsed output. It also sets `additionalProperties: false` to ensure strict validation. Use it whenever you define schemas for JSON parsers.
 
 ```ts
 import { defineSchema, createParser } from "llm-exe";
@@ -1793,6 +1915,10 @@ const parsed = parser.parse(exampleOutputFromLlm);
 The default parser. Doesn't really parse, it passes through the string response with no modification.
 Returns: string
 
+```ts
+const parser = createParser("string");
+```
+
 ::: code-group
 
 ```[Output]
@@ -1808,12 +1934,17 @@ This is an example input message.
 ## Number Parser
 
 `number`
-Extracts a number from the LLM response.
+Extracts exactly one number from the LLM response.
 Returns: number
 
 ```ts
 const parser = createParser("number");
 ```
+
+Options:
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `match` | `"extract" \| "exact"` | `"extract"` | `"extract"` finds one numeric token in the response. `"exact"` requires the entire trimmed response to be one numeric token. |
 
 ::: code-group
 
@@ -1837,6 +1968,11 @@ Returns: boolean
 const parser = createParser("boolean");
 ```
 
+Options:
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `match` | `"exact" \| "extract"` | `"exact"` | `"exact"` requires the entire trimmed response to be one boolean literal. `"extract"` finds one boolean literal in surrounding text. |
+
 ::: code-group
 
 ```[Output]
@@ -1844,7 +1980,7 @@ true
 ```
 
 ```[Response]
-Yes, that is correct.
+yes
 ```
 
 :::
@@ -1868,7 +2004,8 @@ Options:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enum` | `string[]` | `[]` | The list of allowed values to match against. |
-| `ignoreCase` | `boolean` | `false` | When `true`, matching is case-insensitive. |
+| `ignoreCase` | `boolean` | `true` | When `true`, matching is case-insensitive. |
+| `match` | `"word" \| "substring" \| "exact"` | `"word"` | `"word"` matches enum values on word boundaries. `"substring"` uses contains matching. `"exact"` requires the entire trimmed response to equal one enum value. |
 
 ::: code-group
 
@@ -1969,7 +2106,7 @@ Below is the generated code:
 function add(a: number, b: number){
     return a + b;
 }
-``'
+```
 ````
 
 :::
@@ -2004,7 +2141,7 @@ Below is the generated code:
 function add(a: number, b: number){
     return a + b;
 }
-``'
+```
 
 And the next:
 
@@ -2012,7 +2149,7 @@ And the next:
 function subtract(a: number, b: number){
     return a - b;
 }
-``'
+```
 ````
 
 :::
@@ -2024,11 +2161,27 @@ Runs Handlebars substitution on the LLM's output, using the executor's input att
 
 Returns: string
 
-**Use case:** The LLM generates a response containing placeholders, and the parser fills them in with known values from the executor input — useful for personalized messages, dynamic templates, or mail-merge patterns.
-
 ```ts
 const parser = createParser("replaceStringTemplate");
 ```
+
+**Use case:** The LLM generates a response containing placeholders, and the parser fills them in with known values from the executor input — useful for personalized messages, dynamic templates, or mail-merge patterns.
+
+::: code-group
+
+```[Output]
+Hello Alice! Your order #12345 has shipped.
+```
+
+```[Response]
+Hello {{name}}! Your order #{{orderId}} has shipped.
+```
+
+```[Attributes passed to parser]
+{ name: "Alice", orderId: "12345" }
+```
+
+:::
 
 ## List to JSON
 
@@ -2037,17 +2190,21 @@ Parses key:value lines (separated by newlines) into a **single flat object**. Ea
 
 Returns: object (flat key-value pairs)
 
+::: warning
+This parser produces a single object, not an array. If the LLM output contains duplicate keys, later values overwrite earlier ones. If you need to preserve multiple records with the same keys, use [`listToKeyValue`](#list-to-key-value) instead (which returns an array of `{ key, value }` pairs).
+:::
+
+> **Example Prompt:** <br>Extract the following information. Reply only with: Color: the color\nName: the name\nType: the type
+
+```typescript
+const parser = createParser("listToJson");
+```
+
 Options:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `keyTransform` | `"camelCase" \| "preserve"` | `"camelCase"` | How to transform keys. `"camelCase"` converts keys like "First Name" to "firstName". `"preserve"` keeps the original key text (trimmed). |
 | `schema` | `JSONSchema` | `undefined` | Optional JSON Schema to validate and enforce types on the output. |
-
-> **Example Prompt:** <br>You need to extract the following information. Reply only with: Color: the color\nName: the name\nType: the type
-
-```typescript
-const parser = createParser("listToJson");
-```
 
 ::: code-group
 
@@ -2067,10 +2224,28 @@ Type: Fruit
 
 :::
 
+**Choosing between `listToJson` and `listToKeyValue`:**
+
+| Parser | Returns | Best for |
+| --- | --- | --- |
+| `listToJson` | `{ key: value, ... }` (flat object) | Extracting a fixed set of unique fields from a response |
+| `listToKeyValue` | `Array<{ key, value }>` | Preserving order, handling duplicate keys, or iterating over pairs |
+
 ## JSON
 
 `json`
-Parse an expected stringified json object or array into a valid object. Schema can be passed in to enforce schema and provide default values.
+Parse an expected stringified JSON object or array into a valid object. Schema can be passed in to enforce schema and provide default values.
+Returns: object | array
+
+```ts
+const parser = createParser("json");
+```
+
+Options:
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `schema` | `JSONSchema` | `undefined` | Optional JSON Schema to validate and enforce types on the output. Use with [`defineSchema`](/parser/index.html#defineschema) for full type inference. |
+| `match` | `"exact" \| "extract"` | `"exact"` | `"exact"` parses the entire response as JSON. `"extract"` finds one JSON object or array in surrounding text. |
 
 ::: code-group
 
@@ -2222,33 +2397,49 @@ userIntent.resetValue();  // resets to "unknown"
 
 **Attributes** are a simple key-value store for lightweight metadata. Use `state.setAttribute(key, value)`, `state.deleteAttribute(key)`, and `state.clearAttributes()`.
 
-State has a `saveState()` method that can be customized to save the state to a database.
+## Creating State
 
-Initializing a state object is as simple as:
+Initializing a state object is simple:
 ```ts
-const state = createState()
+import { createState } from "llm-exe";
+
+const state = createState();
 ```
 
-If you wanted to store a chat conversation dialogue, you could:
+## Dialogues
+
+If you want to store a chat conversation dialogue, create one on the state:
 ```ts
-const state = createState()
+const state = createState();
 
 // this creates a new dialogue in the state, and returns it
 const chatHistory = state.createDialogue("chatHistory");
 
-// we can use this directly
-// chatHistory.setUserMessage("Hey anyone there?");
+// add messages directly
+chatHistory.setUserMessage("Hey anyone there?");
 
-
-// or get again from state object
-// state.getDialogue("chatHistory").setAssistantMessage("Yep! Whats up?");
+// or retrieve from state later
+state.getDialogue("chatHistory").setAssistantMessage("Yep! What's up?");
 ```
 
+You can also create a standalone dialogue without state using `createDialogue`. See the [Dialogue](/state/dialogue.html) page for full details.
 
-Saving state
+## Saving State
+
+The `DefaultState` class implements `saveState()` with a warning log by default. To persist state, extend `DefaultState` and override it with your own save logic:
+
 ```ts
-// this needs to be implemented by you if you want to save somewhere
-await state.saveState()
+import { DefaultState } from "llm-exe";
+
+class MyState extends DefaultState {
+  async saveState() {
+    const data = {
+      dialogues: this.dialogues,
+      attributes: this.attributes,
+    };
+    await db.save("state", JSON.stringify(data));
+  }
+}
 ```
 ---
 
@@ -2412,6 +2603,40 @@ const response = await executor.execute({ input: "Hello!" });
 
 `createLlmExecutor` Returns an instance of LlmExecutor.
 
+## Function Executor
+
+If you need tool/function calling support, use `createLlmFunctionExecutor`. It extends the standard LLM executor with the ability to define functions the LLM can call. This works with any provider that supports tool calling (OpenAI, Anthropic, Google, etc.).
+
+```typescript
+import { useLlm, createChatPrompt, createLlmFunctionExecutor } from "llm-exe";
+
+const llm = useLlm("openai.gpt-4o-mini");
+const prompt = createChatPrompt("You are a helpful assistant.");
+
+const executor = createLlmFunctionExecutor({
+  llm,
+  prompt,
+});
+
+const response = await executor.execute(
+  { input: "What's the weather?" },
+  {
+    functionCall: "auto",
+    functions: [
+      {
+        name: "get_weather",
+        description: "Get the current weather",
+        parameters: { /* JSON Schema */ },
+      },
+    ],
+  }
+);
+```
+
+`createLlmFunctionExecutor` Returns an instance of LlmExecutorWithFunctions.
+
+See [Tool Calling Executor](/executor/openai-functions.html) for full documentation and examples.
+
 ## Core Executor
 
 If you need a typed executor that wraps a plain function (no LLM involved), use `createCoreExecutor`. This is useful for composing non-LLM steps alongside LLM executors in a pipeline — the core executor provides the same `execute` interface, tracing, and hooks as an LLM executor.
@@ -2486,59 +2711,161 @@ Hooks are available mostly for logging purposes, but can have more advanced use-
 
 The following hooks are available:
 
-- onComplete
-- onSuccess
-- onError
+- `onSuccess` — runs after a successful execution, once the output has been produced
+- `onError` — runs when the executor throws, before the error is re-thrown
+- `onComplete` — runs after `onSuccess` or `onError`, regardless of outcome
+
+### Hook Signature
+
+Every hook receives the same two arguments:
+
+```typescript
+type Hook = (
+  executionMetadata: ExecutorExecutionMetadata,
+  executorMetadata: ExecutorMetadata
+) => void;
+```
+
+`executionMetadata` contains information about this specific execution (input, output, timings, and — for `onError` — the thrown error). `executorMetadata` contains information about the executor instance itself (id, type, name, total executions).
+
+| Field                              | Available on              | Description                                      |
+| ---------------------------------- | ------------------------- | ------------------------------------------------ |
+| `executionMetadata.input`          | all hooks                 | The input passed to `.execute()`                 |
+| `executionMetadata.output`         | `onSuccess`, `onComplete` | The parsed output returned by the executor       |
+| `executionMetadata.handlerInput`   | all hooks                 | The transformed input passed to the internal handler |
+| `executionMetadata.handlerOutput`  | `onSuccess`, `onComplete` | The raw handler output before parsing            |
+| `executionMetadata.error`          | `onError`, `onComplete`   | The thrown `Error` instance                      |
+| `executionMetadata.errorMessage`   | `onError`, `onComplete`   | Shortcut for `error.message`                     |
+| `executionMetadata.errorCategory`  | `onError`, `onComplete`   | Structured category for `LlmExeError` failures  |
+| `executionMetadata.errorCode`      | `onError`, `onComplete`   | Structured code for `LlmExeError` failures      |
+| `executionMetadata.errorContext`   | `onError`, `onComplete`   | Structured context for `LlmExeError` failures   |
+| `executionMetadata.hookErrors`     | later hooks               | Failures captured from earlier hook callbacks   |
+| `executionMetadata.start`          | all hooks                 | Execution start time (ms since epoch)            |
+| `executionMetadata.end`            | `onComplete`              | Execution end time (ms since epoch)              |
+| `executorMetadata.id`              | all hooks                 | Stable id of the executor                        |
+| `executorMetadata.name`            | all hooks                 | Name of the executor, if set                     |
+| `executorMetadata.type`            | all hooks                 | Type of executor (e.g. `"llm-executor"`)         |
+| `executorMetadata.created`         | all hooks                 | Timestamp when the executor was created (ms since epoch) |
+| `executorMetadata.executions`      | all hooks                 | Number of times this executor has run            |
+
+Hooks should be synchronous and lightweight. Errors thrown inside a hook are caught and collected by llm-exe. They do not affect the executor result.
+
+### Hook Errors
+
+If an `onSuccess` or `onError` hook throws, the failure is captured in `executionMetadata.hookErrors` for later hooks such as `onComplete`.
+
+```typescript:no-line-numbers
+executor.on("onSuccess", () => {
+  throw new Error("logging failed");
+});
+
+executor.on("onComplete", (exec) => {
+  console.log(exec.hookErrors?.[0]?.errorMessage);
+});
+```
+
+Each hook error record includes the raw thrown value and `errorMessage`. If the thrown value is an `LlmExeError`, `errorCategory`, `errorCode`, `errorContext`, and `errorCause` are included.
+
+`onComplete` runs last. If an `onComplete` hook throws, there is no later hook where that failure can be surfaced in execution metadata.
 
 You can attach hooks:
 
 - During initialization
-- After initialization using on/off/once
+- After initialization using `on` / `off` / `once`
 
-#### Adding hooks during initialization:
+#### Adding hooks during initialization
 
-```typescript{2,5}:no-line-numbers
-// You can pass in hooks object
-const hooks = { onComplete: logFunction, onError: logFunctionError };
+```typescript{5}:no-line-numbers
+const hooks = {
+  onSuccess: (exec) => console.log("output:", exec.output),
+  onError: (exec) => console.error("failed:", exec.errorMessage),
+};
 const llm = useLlm("openai.chat-mock.v1", {});
 const prompt = createChatPrompt("This is a prompt.");
 const executor = createLlmExecutor({ llm, prompt }, { hooks });
 ```
 
-#### Adding hooks after initialization:
+#### Adding hooks after initialization
 
-```typescript{13,14}:no-line-numbers
-function logFunction() {
-  console.log("its done!!");
+Use `.on()` to attach a hook, and `.off()` to remove it.
+
+```typescript{10,11,14}:no-line-numbers
+function logSuccess(exec) {
+  console.log("output:", exec.output);
 }
 
-function logFunctionError() {
-  console.log("its done!!");
+function logError(exec) {
+  console.error("failed:", exec.errorMessage);
 }
 
-// You can also use on to listen
-const llm = useLlm("openai.chat-mock.v1", {});
-const prompt = createChatPrompt("This is a prompt.");
 const executor = createLlmExecutor({ llm, prompt });
-executor.on("onComplete", logFunction);
-executor.on("onError", logFunctionError);
-return executor.execute({});
+executor.on("onSuccess", logSuccess);
+executor.on("onError", logError);
+
+// Later, detach a specific listener:
+executor.off("onSuccess", logSuccess);
 ```
 
-You can also use `.once` to add a hook that get executed exactly once
+#### Listening exactly once
 
-```typescript{5}:no-line-numbers
-// You can also use once to listen once
-const llm = useLlm("openai.chat-mock.v1", {});
-const prompt = createChatPrompt("This is a prompt.");
+Use `.once()` to add a hook that fires on the next execution only and then detaches itself.
+
+```typescript{3}:no-line-numbers
 const executor = createLlmExecutor({ llm, prompt });
-executor.once("onComplete", logFunction);
-return executor.execute({});
+
+executor.once("onComplete", (exec) => {
+  console.log(`first run took ${exec.end - exec.start}ms`);
+});
+
+await executor.execute({});
+await executor.execute({}); // the once handler no longer fires
 ```
 
 ::: tip
-Default behavior is to not add the same handler to the same hook more than once.
+Default behavior is to not add the same handler to the same hook more than once. There is also a per-event hook limit to prevent unbounded memory growth — if you hit it, remove unused hooks with `.off()` rather than piling on new ones.
 :::
+
+#### Clearing hooks
+
+Use `.clearHooks()` to remove all hooks for a specific event, or all events at once. This is useful for preventing memory leaks in long-running processes.
+
+```typescript{3,6}:no-line-numbers
+const executor = createLlmExecutor({ llm, prompt });
+
+// Clear hooks for a specific event
+executor.clearHooks("onSuccess");
+
+// Clear all hooks across all events
+executor.clearHooks();
+```
+
+#### Inspecting hook count
+
+Use `.getHookCount()` to check how many hooks are registered, either for a specific event or across all events.
+
+```typescript{3,6}:no-line-numbers
+const executor = createLlmExecutor({ llm, prompt });
+
+// Get count for a specific event
+const count = executor.getHookCount("onSuccess"); // number
+
+// Get counts for all events
+const counts = executor.getHookCount(); // { onSuccess: 0, onError: 0, onComplete: 0 }
+```
+
+#### Trace ID
+
+Use `.withTraceId()` to associate an executor with a trace identifier for observability. The trace ID is included in `executorMetadata` passed to hooks.
+
+```typescript{3}:no-line-numbers
+const executor = createLlmExecutor({ llm, prompt });
+
+executor.withTraceId("req-abc-123");
+
+executor.on("onComplete", (exec, meta) => {
+  console.log(meta.traceId); // "req-abc-123"
+});
+```
 
 ---
 
@@ -2562,9 +2889,9 @@ const executor = createLlmExecutor(
   },
   {
     hooks: {
-      onComplete: () => console.log("Done"),
-      onSuccess: (result) => console.log("Result:", result),
-      onError: (error) => console.error("Error:", error),
+      onSuccess: (exec) => console.log("Result:", exec.output),
+      onError: (exec) => console.error("Error:", exec.errorMessage),
+      onComplete: (exec) => console.log(`Done in ${exec.end - exec.start}ms`),
     },
   }
 );
@@ -2598,147 +2925,6 @@ const result = await executor.execute(
 | Option     | Type                      | Description                                         |
 | ---------- | ------------------------- | --------------------------------------------------- |
 | jsonSchema | `Record<string, any>`     | JSON schema to pass to the LLM for structured output |
-
----
-
-# Callable Executor
-
-When building LLM agents that need to call tools or functions, `createCallableExecutor` wraps your executors (or plain functions) into a standardized interface. Use `useExecutors` to group them into a collection you can query and invoke by name.
-
-## Creating a callable executor
-
-Use `createCallableExecutor` to wrap a handler function or an existing executor.
-
-**Config properties:**
-
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `name` | `string` | Yes | Unique name used to look up and invoke the function |
-| `description` | `string` | Yes | Description of what the function does (shown to the LLM) |
-| `input` | `string` | Yes | JSON-stringified schema describing the expected input shape |
-| `handler` | `function \| BaseExecutor` | No | The function to execute, or an existing executor instance |
-| `parameters` | `Record<string, any>` | No | Additional static parameters passed alongside the input |
-| `attributes` | `Record<string, any>` | No | Metadata attributes returned with the result |
-| `visibilityHandler` | `function` | No | Controls whether this function is visible in a given context |
-| `validateInput` | `function` | No | Validates input before execution |
-
-```ts
-import { createCallableExecutor, createLlmExecutor, useLlm, createChatPrompt, createParser } from "llm-exe";
-
-// Wrap a plain function
-const searchCallable = createCallableExecutor({
-  name: "searchInternet",
-  description: "Search the internet for information",
-  input: JSON.stringify({
-    type: "object",
-    properties: {
-      query: { type: "string", description: "The search query" },
-    },
-  }),
-  handler: async (input: { query: string }) => {
-    return { results: [`Result for: ${input.query}`] };
-  },
-});
-
-// Or wrap an existing LlmExecutor
-const summarizeExecutor = createLlmExecutor({
-  llm: useLlm("openai.chat.v1", { model: "gpt-4o-mini" }),
-  prompt: createChatPrompt("Summarize: {{input}}"),
-  parser: createParser("string"),
-});
-
-const summarizeCallable = createCallableExecutor({
-  name: "summarize",
-  description: "Summarize the given text",
-  input: JSON.stringify({
-    type: "object",
-    properties: {
-      input: { type: "string", description: "Text to summarize" },
-    },
-  }),
-  handler: summarizeExecutor,
-});
-```
-
-## Grouping with `useExecutors`
-
-`useExecutors` groups callables into a collection with lookup and invocation methods:
-
-```ts
-import { useExecutors } from "llm-exe";
-
-const executors = useExecutors([searchCallable, summarizeCallable]);
-
-// Check if a function exists
-executors.hasFunction("searchInternet"); // true
-
-// Get a function by name
-const fn = executors.getFunction("searchInternet");
-
-// Call a function by name — input is parsed from a JSON string
-const result = await executors.callFunction(
-  "searchInternet",
-  JSON.stringify({ query: "llm-exe docs" })
-);
-// result: { result: any, attributes: any }
-
-// Get all functions (useful for building tool lists)
-const allFunctions = executors.getFunctions();
-```
-
-## Optional features
-
-**Visibility handler** — conditionally show/hide functions based on context:
-
-```ts
-const adminCallable = createCallableExecutor({
-  name: "deleteUser",
-  description: "Delete a user account",
-  input: JSON.stringify({
-    type: "object",
-    properties: {
-      userId: { type: "string", description: "The ID of the user to delete" },
-    },
-  }),
-  handler: async (input: { userId: string }) => { /* ... */ },
-  visibilityHandler: (input, context, attributes) => {
-    return attributes?.role === "admin";
-  },
-});
-
-// Only returns functions visible for the given context
-const visible = executors.getVisibleFunctions(input, { role: "admin" });
-```
-
-**Input validation** — validate input before execution:
-
-```ts
-const callable = createCallableExecutor({
-  name: "sendEmail",
-  description: "Send an email",
-  input: JSON.stringify({
-    type: "object",
-    properties: {
-      to: { type: "string", description: "Recipient email address" },
-      subject: { type: "string", description: "Email subject line" },
-      body: { type: "string", description: "Email body content" },
-    },
-  }),
-  handler: async (input: { to: string; subject: string; body: string }) => { /* ... */ },
-  validateInput: async (input) => {
-    if (!input.to) {
-      return { result: false, attributes: { error: "Missing 'to' field" } };
-    }
-    return { result: true, attributes: {} };
-  },
-});
-
-const validation = await executors.validateFunctionInput(
-  "sendEmail",
-  JSON.stringify({ subject: "Hi" })
-);
-// validation: { result: false, attributes: { error: "Missing 'to' field" } }
-```
 
 ---
 
@@ -2873,81 +3059,26 @@ console.log(vector);
 
 ---
 
-
-# Cohere Embeddings (via AWS Bedrock)
-
-When using Cohere embeddings, llm-exe will make POST requests to the AWS Bedrock endpoint for your configured region. Both Cohere Embed v3 and Embed v4 are supported through a single provider key — pick the variant via the `model` option.
-
-## Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `model` | `string` | — | The Bedrock model ID (e.g., `cohere.embed-english-v3`, `cohere.embed-multilingual-v3`, `cohere.embed-v4:0`) |
-| `inputType` | `"search_document" \| "search_query" \| "classification" \| "clustering"` | `"search_document"` | How Cohere should prepare the embedding. Use `search_document` for the corpus you index and `search_query` for queries you embed at search time |
-| `truncate` | `"NONE" \| "START" \| "END" \| "LEFT" \| "RIGHT"` | — | How over-length inputs are handled. `START`/`END` for v3, `LEFT`/`RIGHT` for v4. `NONE` returns an error if the input is too long |
-| `dimensions` | `number` | — | Output vector size. For Embed v4: `256`, `512`, `1024`, or `1536` (maps to Cohere's `output_dimension`). For Embed v3: the model has a fixed 1024-dim output — passing `1024` is accepted as a no-op, any other value throws immediately so you don't silently get a different dimension than you asked for |
-| `awsRegion` | `string` | `AWS_REGION` env var | The AWS region for the Bedrock endpoint (required) |
-| `awsSecretKey` | `string` | — | AWS secret key (if not using default credentials) |
-| `awsAccessKey` | `string` | — | AWS access key (if not using default credentials) |
-
-## Basic Usage
-
-```ts
-import { createEmbedding } from "llm-exe";
-
-const embeddings = createEmbedding("amazon:cohere.embedding.v1", {
-  model: "cohere.embed-multilingual-v3",
-  awsRegion: "us-west-2",
-});
-
-const embedding = await embeddings.call("The string of text you would like as vector");
-const vector = embedding.getEmbedding();
-```
-
-## Batching
-
-Cohere accepts up to 96 texts per call. Pass an array to embed them in a single request:
-
-```ts
-const embedding = await embeddings.call([
-  "RAG system design patterns",
-  "Actuarial loss triangles and reserving primer",
-]);
-
-const first = embedding.getEmbedding(0);
-const second = embedding.getEmbedding(1);
-```
-
-## Search vs Indexing
-
-For retrieval (RAG) workflows, embed your corpus with `inputType: "search_document"` and your queries with `inputType: "search_query"`. Cohere prepends different special tokens for each case, which improves retrieval quality.
-
-## Embed v4 Output Dimensions
-
-Cohere Embed v4 supports variable output dimensions via `dimensions` (`256`, `512`, `1024`, or `1536`). Smaller vectors trade off some retrieval quality for cheaper storage and faster nearest-neighbor lookups.
-
-```ts
-const embeddings = createEmbedding("amazon:cohere.embedding.v1", {
-  model: "cohere.embed-v4:0",
-  dimensions: 512,
-});
-```
-
-## Notes
-
-- Cohere on Bedrock does not return token usage, so `getResult().usage.input_tokens` will be `0`.
-- Cohere models on Bedrock are served from AWS Marketplace. The first invocation in your account must come from a user with `aws-marketplace:Subscribe` permissions, after which all users in the account can invoke the model.
-- llm-exe is text-only; image inputs to Cohere Embed v3/v4 are not supported.
-
----
-
 ## Callable Executor Wrapper
 
 When building LLM agents that need to call tools or functions, `createCallableExecutor` wraps your executors (or plain functions) into a standardized interface. Use `useExecutors` to group them into a collection you can query and invoke by name.
 
 ### Creating a callable executor
 
-Use `createCallableExecutor` to wrap a handler function or an existing executor:
+Use `createCallableExecutor` to wrap a handler function or an existing executor.
+
+**Config properties:**
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Unique name used to look up and invoke the function |
+| `description` | `string` | Yes | Description of what the function does (shown to the LLM) |
+| `input` | `string` | Yes | JSON-stringified schema describing the expected input shape |
+| `handler` | `function \| BaseExecutor` | No | The function to execute, or an existing executor instance |
+| `parameters` | `Record<string, any>` | No | Additional static parameters passed alongside the input |
+| `attributes` | `Record<string, any>` | No | Metadata attributes returned with the result |
+| `visibilityHandler` | `function` | No | Controls whether this function is visible in a given context |
+| `validateInput` | `function` | No | Validates input before execution |
 
 ```ts
 import { createCallableExecutor, createLlmExecutor, useLlm, createChatPrompt, createParser } from "llm-exe";
@@ -3025,8 +3156,13 @@ const allFunctions = executors.getFunctions();
 const adminCallable = createCallableExecutor({
   name: "deleteUser",
   description: "Delete a user account",
-  input: "...",
-  handler: async (input) => { /* ... */ },
+  input: JSON.stringify({
+    type: "object",
+    properties: {
+      userId: { type: "string", description: "The ID of the user to delete" },
+    },
+  }),
+  handler: async (input: { userId: string }) => { /* ... */ },
   visibilityHandler: (input, context, attributes) => {
     return attributes?.role === "admin";
   },
@@ -3042,8 +3178,15 @@ const visible = executors.getVisibleFunctions(input, { role: "admin" });
 const callable = createCallableExecutor({
   name: "sendEmail",
   description: "Send an email",
-  input: "...",
-  handler: async (input) => { /* ... */ },
+  input: JSON.stringify({
+    type: "object",
+    properties: {
+      to: { type: "string", description: "Recipient email address" },
+      subject: { type: "string", description: "Email subject line" },
+      body: { type: "string", description: "Email body content" },
+    },
+  }),
+  handler: async (input: { to: string; subject: string; body: string }) => { /* ... */ },
   validateInput: async (input) => {
     if (!input.to) {
       return { result: false, attributes: { error: "Missing 'to' field" } };
@@ -3057,6 +3200,28 @@ const validation = await executors.validateFunctionInput(
   JSON.stringify({ subject: "Hi" })
 );
 // validation: { result: false, attributes: { error: "Missing 'to' field" } }
+```
+
+### Callable Errors
+
+Callable executor failures use structured `LlmExeError` codes:
+
+| Code | Meaning |
+| --- | --- |
+| `callable.invalid_handler` | The callable was created without a valid function or executor handler |
+| `callable.handler_not_found` | `useExecutors` could not find a callable with the requested name |
+| `callable.validation_failed` | Callable input validation failed |
+
+Use `isLlmExeError` to check callable failure codes.
+
+```ts
+try {
+  await executors.callFunction("sendEmail", input);
+} catch (error) {
+  if (isLlmExeError(error, "callable.handler_not_found")) {
+    // Ask the model to choose one of the available functions.
+  }
+}
 ```
 
 ### Using with an LLM agent loop
@@ -3079,6 +3244,7 @@ const functionWithCallableExecutors = async (input: {
   return executors.callFunction(input.action, input.input);
 };
 ```
+
 ---
 
 # LLM Executor Function Syntax

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -43,19 +43,13 @@
 
 ### Executor
 - [LLM Executor](https://llm-exe.com/executor/index.html)
-- [Executor Options](https://llm-exe.com/executor/options.html)
 - [Tool Calling Executor](https://llm-exe.com/executor/openai-functions.html)
-- [Callable Executor](https://llm-exe.com/callable/index.html)
-- [Hooks](https://llm-exe.com/executor/hooks.html)
+- [hooks](https://llm-exe.com/executor/hooks.html)
 
 ### Embeddings
 - [Embeddings](https://llm-exe.com/embeddings/index.html)
 - [OpenAI Embeddings](https://llm-exe.com/embeddings/openai.html)
 - [Amazon Embeddings](https://llm-exe.com/embeddings/amazon.html)
-- [Cohere Embeddings (via Bedrock)](https://llm-exe.com/embeddings/cohere.html)
-
-### Callable
-- [Callable Executors](https://llm-exe.com/callable/index.html)
 
 ### Examples
 - [LLM Executor Function Syntax](https://llm-exe.com/examples/FunctionSyntax.html)

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Welcome back!
 ```ts
 createParser("string");              // pass-through, returns string
 createParser("json", { schema });    // JSON with optional schema validation
-createParser("boolean");             // extracts boolean from response
+createParser("boolean");             // parses a boolean token
 createParser("number");              // extracts number from response
 createParser("stringExtract", { enum: ["yes", "no"] }); // match one of the enum values
 createParser("listToArray");         // newline-separated list → string[]

--- a/src/__scenarios__/mock.scenarios.test.ts
+++ b/src/__scenarios__/mock.scenarios.test.ts
@@ -9,10 +9,7 @@ import { useLlm } from "@/llm";
 import { createChatPrompt } from "@/prompt";
 import { createParser, createCustomParser } from "@/parser";
 import { JsonParser } from "@/parser";
-import {
-  createLlmExecutor,
-  createCoreExecutor,
-} from "@/executor/_functions";
+import { createLlmExecutor, createCoreExecutor } from "@/executor/_functions";
 import { createDialogue, createState } from "@/state";
 import { BaseLlmOutput } from "@/llm/output/base";
 import { defineSchema } from "@/utils/modules/defineSchema";
@@ -39,9 +36,7 @@ import {
 describe("Scenario: BaseLlmOutput wrapping", () => {
   it("wraps simple text and exposes getResultText", () => {
     const wrapped = BaseLlmOutput(SIMPLE_TEXT);
-    expect(wrapped.getResultText()).toEqual(
-      "The capital of France is Paris."
-    );
+    expect(wrapped.getResultText()).toEqual("The capital of France is Paris.");
   });
 
   it("wraps function call and exposes getResult", () => {
@@ -104,9 +99,7 @@ describe("Scenario: Dialogue management", () => {
       dialogue
         .setSystemMessage("You are a helpful assistant.")
         .setUserMessage("What is TypeScript?")
-        .setAssistantMessage(
-          "TypeScript is a typed superset of JavaScript."
-        );
+        .setAssistantMessage("TypeScript is a typed superset of JavaScript.");
 
       const history = dialogue.getHistory();
       expect(history).toHaveLength(3);
@@ -128,7 +121,7 @@ describe("Scenario: Dialogue management", () => {
         .setFunctionMessage(
           '{"temp": 65, "condition": "foggy"}',
           "get_weather",
-          "call_100"
+          "call_100",
         )
         .setAssistantMessage("It's 65°F and foggy in San Francisco.");
 
@@ -240,12 +233,12 @@ describe("Scenario: Dialogue management", () => {
       dialogue.setFunctionMessage(
         '{"temp": 65, "condition": "foggy"}',
         "get_weather",
-        "call_001"
+        "call_001",
       );
       dialogue.setFunctionMessage(
         '{"temp": 45, "condition": "clear"}',
         "get_weather",
-        "call_002"
+        "call_002",
       );
 
       // Turn 4: LLM summarizes
@@ -344,7 +337,7 @@ describe("Scenario: Parser with mock outputs", () => {
     expect(parser.parse(PARSER_INPUTS.number)).toEqual(42);
   });
 
-  it("BooleanParser extracts boolean", () => {
+  it("BooleanParser parses boolean tokens", () => {
     const parser = createParser("boolean");
     expect(parser.parse(PARSER_INPUTS.booleanTrue)).toEqual(true);
     expect(parser.parse(PARSER_INPUTS.booleanFalse)).toEqual(false);
@@ -378,7 +371,7 @@ describe("Scenario: Parser with mock outputs", () => {
 
   it("CustomParser applies custom logic", () => {
     const parser = createCustomParser("upper", (input: string) =>
-      input.toUpperCase()
+      input.toUpperCase(),
     );
     expect(parser.parse("hello world", {} as any)).toEqual("HELLO WORLD");
   });
@@ -389,28 +382,26 @@ describe("Scenario: Parser with mock outputs", () => {
 describe("Scenario: ChatPrompt templates", () => {
   it("renders system message with template variables", () => {
     const prompt = createChatPrompt(
-      "You are helping {{name}} with their question."
+      "You are helping {{name}} with their question.",
     );
     const messages = prompt.format(TEMPLATE_INPUTS.simple);
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toEqual(
-      "You are helping Alice with their question."
+      "You are helping Alice with their question.",
     );
   });
 
   it("renders with nested object access", () => {
     const prompt = createChatPrompt(
-      "Respond in {{user.preferences.language}} with a {{user.preferences.tone}} tone."
+      "Respond in {{user.preferences.language}} with a {{user.preferences.tone}} tone.",
     );
     const messages = prompt.format(TEMPLATE_INPUTS.withNested);
-    expect(messages[0].content).toEqual(
-      "Respond in en with a formal tone."
-    );
+    expect(messages[0].content).toEqual("Respond in en with a formal tone.");
   });
 
   it("renders with each helper for arrays", () => {
     const prompt = createChatPrompt(
-      "Items: {{#each items}}{{this}}, {{/each}}"
+      "Items: {{#each items}}{{this}}, {{/each}}",
     );
     const messages = prompt.format(TEMPLATE_INPUTS.withArray);
     expect(messages[0].content).toContain("apple");
@@ -468,7 +459,7 @@ describe("Scenario: LlmExecutor with mock LLM", () => {
     const onComplete = jest.fn();
     const executor = createLlmExecutor(
       { llm, prompt },
-      { hooks: { onSuccess, onComplete } }
+      { hooks: { onSuccess, onComplete } },
     );
 
     await executor.execute({});
@@ -483,7 +474,7 @@ describe("Scenario: LlmExecutor with mock LLM", () => {
 
     const executor = createLlmExecutor(
       { llm, prompt: undefined as any },
-      { hooks: { onError, onComplete } }
+      { hooks: { onError, onComplete } },
     );
 
     await expect(executor.execute({})).rejects.toThrow();
@@ -497,18 +488,16 @@ describe("Scenario: LlmExecutor with mock LLM", () => {
 describe("Scenario: CoreExecutor for non-LLM handlers", () => {
   it("wraps a sync handler", async () => {
     const executor = createCoreExecutor(
-      (input: { x: number; y: number }) => input.x + input.y
+      (input: { x: number; y: number }) => input.x + input.y,
     );
     const result = await executor.execute({ x: 3, y: 4 });
     expect(result).toEqual(7);
   });
 
   it("wraps an async handler", async () => {
-    const executor = createCoreExecutor(
-      async (input: { query: string }) => {
-        return { results: [`Found: ${input.query}`] };
-      }
-    );
+    const executor = createCoreExecutor(async (input: { query: string }) => {
+      return { results: [`Found: ${input.query}`] };
+    });
     const result = await executor.execute({ query: "test" });
     expect(result).toEqual({ results: ["Found: test"] });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,4 +70,15 @@ export type {
   LlmProviderKey,
   EmbeddingProviderKey,
   UseLlmKey,
+  JsonParserMatch,
+  JsonParserOptions,
 } from "./interfaces";
+
+export type {
+  BooleanParserMatch,
+  BooleanParserOptions,
+  NumberParserMatch,
+  NumberParserOptions,
+  StringExtractMatch,
+  StringExtractParserOptions,
+} from "./parser";

--- a/src/interfaces/parser.ts
+++ b/src/interfaces/parser.ts
@@ -13,23 +13,30 @@ export type CreateParserType =
   | "markdownCodeBlocks"
   | "markdownCodeBlock";
 
-export interface JsonParserOptions<
+export interface ParserSchemaOptions<
   S extends JSONSchema | undefined = undefined,
 > {
   schema?: S;
   validateSchema?: boolean;
 }
 
+export type JsonParserMatch = "exact" | "extract";
+
+export interface JsonParserOptions<S extends JSONSchema | undefined = undefined>
+  extends ParserSchemaOptions<S> {
+  match?: JsonParserMatch;
+}
+
 export interface ListToJsonParserOptions<
   S extends JSONSchema | undefined = undefined,
-> extends JsonParserOptions<S> {
+> extends ParserSchemaOptions<S> {
   keyTransform?: "camelCase" | "preserve";
 }
 
 /**
- * @deprecated Use `JsonParserOptions` instead. Kept for the schema-bearing
+ * @deprecated Use `ParserSchemaOptions` instead. Kept for the schema-bearing
  * BaseParserWithJson constructor; not part of any v3 public surface.
  */
 export type BaseParserOptionsWithSchema<
   S extends JSONSchema | undefined = undefined,
-> = JsonParserOptions<S>;
+> = ParserSchemaOptions<S>;

--- a/src/parser/_base.ts
+++ b/src/parser/_base.ts
@@ -1,4 +1,4 @@
-import { JsonParserOptions } from "@/types";
+import { ParserSchemaOptions } from "@/types";
 import { FromSchema, JSONSchema } from "json-schema-to-ts";
 
 /**
@@ -35,7 +35,7 @@ export abstract class BaseParserWithJson<
   public schema: S;
   public validateSchema: boolean;
 
-  constructor(name: string, options: JsonParserOptions<S>) {
+  constructor(name: string, options: ParserSchemaOptions<S>) {
     super(name);
 
     const { schema, validateSchema } = options;

--- a/src/parser/_functions.test.ts
+++ b/src/parser/_functions.test.ts
@@ -24,6 +24,11 @@ describe("createParser", () => {
     expect(parser).toBeInstanceOf(BooleanParser);
   });
 
+  it("passes options to BooleanParser", () => {
+    const parser = createParser("boolean", { match: "extract" });
+    expect(parser.parse("The answer is true.")).toBe(true);
+  });
+
   it("creates a NumberParser for type 'number'", () => {
     const parser = createParser("number");
     expect(parser).toBeInstanceOf(NumberParser);
@@ -42,6 +47,13 @@ describe("createParser", () => {
     } as const;
     const parser = createParser("json", { schema });
     expect(parser).toBeInstanceOf(JsonParser);
+  });
+
+  it("passes match options to JsonParser", () => {
+    const parser = createParser("json", { match: "extract" });
+    expect(parser.parse('Here is JSON: {"name":"Greg"}')).toEqual({
+      name: "Greg",
+    });
   });
 
   it("creates a ListToJsonParser for type 'listToJson'", () => {
@@ -123,7 +135,7 @@ describe("createParser", () => {
           "replaceStringTemplate",
           "markdownCodeBlock",
           "markdownCodeBlocks",
-        ])
+        ]),
       );
     }
   });
@@ -131,14 +143,16 @@ describe("createParser", () => {
 
 describe("createCustomParser", () => {
   it("creates a CustomParser with the given name and function", () => {
-    const parser = createCustomParser("my-parser", (text) => text.toUpperCase());
+    const parser = createCustomParser("my-parser", (text) =>
+      text.toUpperCase(),
+    );
     expect(parser).toBeInstanceOf(CustomParser);
     expect(parser.name).toBe("my-parser");
   });
 
   it("parser function is invoked correctly", () => {
     const parser = createCustomParser("reverse", (text) =>
-      text.split("").reverse().join("")
+      text.split("").reverse().join(""),
     );
     const result = parser.parse("hello", {} as any);
     expect(result).toBe("olleh");
@@ -158,7 +172,10 @@ describe("createCustomParser", () => {
   it("can return complex types", () => {
     const parser = createCustomParser("json-extract", (text) => {
       const parsed = JSON.parse(text);
-      return { items: parsed.items as string[], count: parsed.items.length as number };
+      return {
+        items: parsed.items as string[],
+        count: parsed.items.length as number,
+      };
     });
     const result = parser.parse('{"items": ["a", "b", "c"]}', {} as any);
     expect(result).toEqual({ items: ["a", "b", "c"], count: 3 });

--- a/src/parser/_functions.ts
+++ b/src/parser/_functions.ts
@@ -7,7 +7,7 @@ import {
 } from "@/types";
 import { LlmExeError } from "@/errors";
 import { StringParser } from "./parsers/StringParser";
-import { BooleanParser } from "./parsers/BooleanParser";
+import { BooleanParser, BooleanParserOptions } from "./parsers/BooleanParser";
 import { NumberParser } from "./parsers/NumberParser";
 import { JsonParser } from "./parsers/JsonParser";
 import { ListToJsonParser } from "./parsers/ListToJsonParser";
@@ -47,7 +47,7 @@ export type ParserMap<S extends JSONSchema | undefined = undefined> = {
  */
 export type CreateParserArgs =
   | [type: "string", options?: never]
-  | [type: "boolean", options?: never]
+  | [type: "boolean", options?: BooleanParserOptions]
   | [type: "listToArray", options?: never]
   | [type: "markdownCodeBlock", options?: never]
   | [type: "markdownCodeBlocks", options?: never]
@@ -59,7 +59,10 @@ export type CreateParserArgs =
       type: "listToJson",
       options?: ListToJsonParserOptions<JSONSchema | undefined>,
     ]
-  | [type: "stringExtract", options: StringExtractParserOptions<readonly string[]>];
+  | [
+      type: "stringExtract",
+      options: StringExtractParserOptions<readonly string[]>,
+    ];
 
 /**
  * Maps a concrete argument tuple back to the parser instance type, preserving
@@ -67,30 +70,43 @@ export type CreateParserArgs =
  * stringExtract.
  */
 export type CreateParserReturn<A extends readonly unknown[]> =
-  A extends readonly ["string", ...unknown[]] ? StringParser
-  : A extends readonly ["boolean", ...unknown[]] ? BooleanParser
-  : A extends readonly ["number", ...unknown[]] ? NumberParser
-  : A extends readonly ["listToArray", ...unknown[]] ? ListToArrayParser
-  : A extends readonly ["listToKeyValue", ...unknown[]] ? ListToKeyValueParser
-  : A extends readonly ["markdownCodeBlock", ...unknown[]]
-    ? MarkdownCodeBlockParser
-  : A extends readonly ["markdownCodeBlocks", ...unknown[]]
-    ? MarkdownCodeBlocksParser
-  : A extends readonly ["replaceStringTemplate", ...unknown[]]
-    ? ReplaceStringTemplateParser
-  : A extends readonly ["json"] | readonly ["json", undefined]
-    ? JsonParser<undefined>
-  : A extends readonly ["json", JsonParserOptions<infer S>] ? JsonParser<S>
-  : A extends readonly ["listToJson"] | readonly ["listToJson", undefined]
-    ? ListToJsonParser<undefined>
-  : A extends readonly ["listToJson", ListToJsonParserOptions<infer S>]
-    ? ListToJsonParser<S>
-  : A extends readonly [
-      "stringExtract",
-      StringExtractParserOptions<infer E extends readonly string[]>,
-    ]
-    ? StringExtractParser<E>
-  : never;
+  A extends readonly ["string", ...unknown[]]
+    ? StringParser
+    : A extends readonly ["boolean", ...unknown[]]
+      ? BooleanParser
+      : A extends readonly ["number", ...unknown[]]
+        ? NumberParser
+        : A extends readonly ["listToArray", ...unknown[]]
+          ? ListToArrayParser
+          : A extends readonly ["listToKeyValue", ...unknown[]]
+            ? ListToKeyValueParser
+            : A extends readonly ["markdownCodeBlock", ...unknown[]]
+              ? MarkdownCodeBlockParser
+              : A extends readonly ["markdownCodeBlocks", ...unknown[]]
+                ? MarkdownCodeBlocksParser
+                : A extends readonly ["replaceStringTemplate", ...unknown[]]
+                  ? ReplaceStringTemplateParser
+                  : A extends readonly ["json"] | readonly ["json", undefined]
+                    ? JsonParser<undefined>
+                    : A extends readonly ["json", JsonParserOptions<infer S>]
+                      ? JsonParser<S>
+                      : A extends
+                            | readonly ["listToJson"]
+                            | readonly ["listToJson", undefined]
+                        ? ListToJsonParser<undefined>
+                        : A extends readonly [
+                              "listToJson",
+                              ListToJsonParserOptions<infer S>,
+                            ]
+                          ? ListToJsonParser<S>
+                          : A extends readonly [
+                                "stringExtract",
+                                StringExtractParserOptions<
+                                  infer E extends readonly string[]
+                                >,
+                              ]
+                            ? StringExtractParser<E>
+                            : never;
 
 export function createParser<const A extends CreateParserArgs>(
   ...args: A
@@ -115,43 +131,40 @@ export function createParser<const A extends CreateParserArgs>(
     case "replaceStringTemplate":
       return new ReplaceStringTemplateParser() as CreateParserReturn<A>;
     case "boolean":
-      return new BooleanParser() as CreateParserReturn<A>;
+      return new BooleanParser(options) as CreateParserReturn<A>;
     case "number":
       return new NumberParser(options) as CreateParserReturn<A>;
     case "string":
       return new StringParser() as CreateParserReturn<A>;
     default:
-      throw new LlmExeError(
-        `Invalid parser type: "${type}"`,
-        {
-          code: "parser.invalid_type",
-          context: {
-            operation: "createParser",
-            parser: type,
-            availableParsers: [
-              "json",
-              "string",
-              "boolean",
-              "number",
-              "stringExtract",
-              "listToArray",
-              "listToJson",
-              "listToKeyValue",
-              "replaceStringTemplate",
-              "markdownCodeBlock",
-              "markdownCodeBlocks",
-            ],
-            resolution:
-              "Use a registered parser type, or define a custom parser.",
-          },
-        }
-      );
+      throw new LlmExeError(`Invalid parser type: "${type}"`, {
+        code: "parser.invalid_type",
+        context: {
+          operation: "createParser",
+          parser: type,
+          availableParsers: [
+            "json",
+            "string",
+            "boolean",
+            "number",
+            "stringExtract",
+            "listToArray",
+            "listToJson",
+            "listToKeyValue",
+            "replaceStringTemplate",
+            "markdownCodeBlock",
+            "markdownCodeBlocks",
+          ],
+          resolution:
+            "Use a registered parser type, or define a custom parser.",
+        },
+      });
   }
 }
 
 export function createCustomParser<O>(
   name: string,
-  parserFn: (text: string, context: ExecutionContext<any, any>) => O
+  parserFn: (text: string, context: ExecutionContext<any, any>) => O,
 ): CustomParser<ReturnType<typeof parserFn>> {
   return new CustomParser<ReturnType<typeof parserFn>>(name, parserFn);
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -37,3 +37,16 @@ export {
   createParser,
   createCustomParser,
 };
+
+export type {
+  BooleanParserMatch,
+  BooleanParserOptions,
+} from "./parsers/BooleanParser";
+export type {
+  NumberParserMatch,
+  NumberParserOptions,
+} from "./parsers/NumberParser";
+export type {
+  StringExtractMatch,
+  StringExtractParserOptions,
+} from "./parsers/StringExtractParser";

--- a/src/parser/parsers/BooleanParser.test.ts
+++ b/src/parser/parsers/BooleanParser.test.ts
@@ -20,200 +20,242 @@ describe("llm-exe:parser/BooleanParser", () => {
     }
   });
 
-  it('creates class with expected properties', () => {
-    const parser = new BooleanParser()
-    expect(parser).toBeInstanceOf(BaseParser)
-    expect(parser).toBeInstanceOf(BooleanParser)
-    expect(parser).toHaveProperty("name")
-    expect(parser.name).toEqual("boolean")
-  })
+  it("creates class with expected properties", () => {
+    const parser = new BooleanParser();
+    expect(parser).toBeInstanceOf(BaseParser);
+    expect(parser).toBeInstanceOf(BooleanParser);
+    expect(parser).toHaveProperty("name");
+    expect(parser.name).toEqual("boolean");
+  });
   it('parses "true" as true', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("true")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("true")).toEqual(true);
+  });
   it('parses "True" as true (case-insensitive)', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("True")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("True")).toEqual(true);
+  });
   it('parses "yes" as true', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("yes")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("yes")).toEqual(true);
+  });
   it('parses "Yes" as true (case-insensitive)', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("Yes")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("Yes")).toEqual(true);
+  });
   it('parses "y" as true', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("y")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("y")).toEqual(true);
+  });
   it('parses "1" as true', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("1")).toEqual(true)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("1")).toEqual(true);
+  });
   it('parses "false" as false', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("false")).toEqual(false)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("false")).toEqual(false);
+  });
   it('parses "no" as false', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("no")).toEqual(false)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("no")).toEqual(false);
+  });
   it('parses "0" as false', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("0")).toEqual(false)
-  })
+    const parser = new BooleanParser();
+    expect(parser.parse("0")).toEqual(false);
+  });
   it('parses "n" as false', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("n")).toEqual(false)
-  })
-  it('handles whitespace around value', () => {
-    const parser = new BooleanParser()
-    expect(parser.parse("  yes  ")).toEqual(true)
-  })
-  it('throws parser.parse_failed for empty input', () => {
-    const parser = new BooleanParser()
+    const parser = new BooleanParser();
+    expect(parser.parse("n")).toEqual(false);
+  });
+  it("handles whitespace around value", () => {
+    const parser = new BooleanParser();
+    expect(parser.parse("  yes  ")).toEqual(true);
+  });
+  it("throws parser.parse_failed for empty input", () => {
+    const parser = new BooleanParser();
     try {
-      parser.parse("")
-      fail("Expected an error to be thrown")
+      parser.parse("");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toEqual({
         operation: "BooleanParser.parse",
         parser: "boolean",
         reason: "empty_input",
         expected: ["true", "false", "yes", "no", "y", "n", "1", "0"],
         inputLength: 0,
-      })
+      });
     }
-  })
-  it('throws parser.parse_failed for whitespace-only input', () => {
-    const parser = new BooleanParser()
+  });
+  it("throws parser.parse_failed for whitespace-only input", () => {
+    const parser = new BooleanParser();
     try {
-      parser.parse("   ")
-      fail("Expected an error to be thrown")
+      parser.parse("   ");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toEqual({
         operation: "BooleanParser.parse",
         parser: "boolean",
         reason: "empty_input",
         expected: ["true", "false", "yes", "no", "y", "n", "1", "0"],
         inputLength: 3,
-      })
+      });
     }
-  })
-  it('throws parser.parse_failed for unrecognized boolean text', () => {
-    const parser = new BooleanParser()
+  });
+  it("throws parser.parse_failed for unrecognized boolean text", () => {
+    const parser = new BooleanParser();
     try {
-      parser.parse("maybe")
-      fail("Expected an error to be thrown")
+      parser.parse("maybe");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toEqual({
         operation: "BooleanParser.parse",
         parser: "boolean",
         reason: "unrecognized_boolean",
         expected: ["true", "false", "yes", "no", "y", "n", "1", "0"],
+        match: "exact",
         inputLength: 5,
-      })
+      });
     }
-  })
-  it('throws parser.parse_failed instead of extracting boolean values from prose', () => {
-    const parser = new BooleanParser()
-    expect(() => parser.parse("The answer is true.")).toThrow(LlmExeError)
-  })
-  it('throws parser.parse_failed instead of treating conflicting prose as ambiguous extraction', () => {
-    const parser = new BooleanParser()
+  });
+  it("throws parser.parse_failed instead of extracting boolean values from prose", () => {
+    const parser = new BooleanParser();
+    expect(() => parser.parse("The answer is true.")).toThrow(LlmExeError);
+  });
+  it("throws parser.parse_failed instead of treating conflicting prose as ambiguous extraction", () => {
+    const parser = new BooleanParser();
     try {
-      parser.parse("true and false")
-      fail("Expected an error to be thrown")
+      parser.parse("true and false");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toEqual({
         operation: "BooleanParser.parse",
         parser: "boolean",
         reason: "unrecognized_boolean",
         expected: ["true", "false", "yes", "no", "y", "n", "1", "0"],
+        match: "exact",
         inputLength: 14,
-      })
+      });
     }
-  })
-  it('does not include input excerpts in error context by default', () => {
-    const parser = new BooleanParser()
+  });
+  describe("match: extract", () => {
+    it("extracts a boolean value from surrounding text", () => {
+      const parser = new BooleanParser({ match: "extract" });
+      expect(parser.parse("The answer is true.")).toEqual(true);
+      expect(parser.parse("Decision: no.")).toEqual(false);
+    });
+    it("deduplicates equivalent boolean values", () => {
+      const parser = new BooleanParser({ match: "extract" });
+      expect(parser.parse("yes, true, and 1")).toEqual(true);
+      expect(parser.parse("no, false, and 0")).toEqual(false);
+    });
+    it("does not match boolean tokens inside larger words", () => {
+      const parser = new BooleanParser({ match: "extract" });
+      try {
+        parser.parse("Yesterday is not an answer.");
+        fail("Expected an error to be thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(LlmExeError);
+        expect((e as LlmExeError).context).toMatchObject({
+          reason: "unrecognized_boolean",
+          match: "extract",
+        });
+      }
+    });
+    it("throws for conflicting extracted boolean values", () => {
+      const parser = new BooleanParser({ match: "extract" });
+      try {
+        parser.parse("true and false");
+        fail("Expected an error to be thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(LlmExeError);
+        expect((e as LlmExeError).context).toMatchObject({
+          reason: "ambiguous_boolean",
+          expected: "one boolean value",
+          match: "extract",
+          matchCount: 2,
+        });
+      }
+    });
+  });
+  it("does not include input excerpts in error context by default", () => {
+    const parser = new BooleanParser();
     try {
-      parser.parse("sensitive output")
-      fail("Expected an error to be thrown")
+      parser.parse("sensitive output");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).context).not.toHaveProperty("inputExcerpt")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).context).not.toHaveProperty("inputExcerpt");
     }
-  })
-  it('includes a bounded input excerpt when debug mode is enabled', () => {
-    process.env.LLM_EXE_DEBUG = "true"
-    const parser = new BooleanParser()
-    const input = "x".repeat(600)
+  });
+  it("includes a bounded input excerpt when debug mode is enabled", () => {
+    process.env.LLM_EXE_DEBUG = "true";
+    const parser = new BooleanParser();
+    const input = "x".repeat(600);
     try {
-      parser.parse(input)
-      fail("Expected an error to be thrown")
+      parser.parse(input);
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toMatchObject({
         inputLength: 600,
         inputExcerpt: "x".repeat(500),
         inputExcerptTruncated: true,
-      })
+      });
     }
-  })
-  it('includes an untruncated input excerpt when debug mode is enabled for short input', () => {
-    process.env.LLM_EXE_DEBUG = "true"
-    const parser = new BooleanParser()
+  });
+  it("includes an untruncated input excerpt when debug mode is enabled for short input", () => {
+    process.env.LLM_EXE_DEBUG = "true";
+    const parser = new BooleanParser();
     try {
-      parser.parse("maybe")
-      fail("Expected an error to be thrown")
+      parser.parse("maybe");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toMatchObject({
         inputLength: 5,
         inputExcerpt: "maybe",
         inputExcerptTruncated: false,
-      })
+      });
     }
-  })
-  it('throws parser.invalid_input for runtime boolean input', () => {
-    const parser = new BooleanParser()
+  });
+  it("throws parser.invalid_input for runtime boolean input", () => {
+    const parser = new BooleanParser();
     try {
       // @ts-expect-error runtime contract: parser rejects non-string input.
-      parser.parse(true)
-      fail("Expected an error to be thrown")
+      parser.parse(true);
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.invalid_input")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.invalid_input");
       expect((e as LlmExeError).context).toEqual({
         operation: "BooleanParser.parse",
         parser: "boolean",
         reason: "invalid_input_type",
         expected: "string",
         received: "boolean",
-      })
+      });
     }
-  })
-  it('throws parser.parse_failed for null input', () => {
-    const parser = new BooleanParser()
+  });
+  it("throws parser.parse_failed for null input", () => {
+    const parser = new BooleanParser();
     expect(() => {
       // @ts-expect-error runtime contract: parser rejects null input.
-      parser.parse(null)
-    }).toThrow(LlmExeError)
-  })
-  it('throws parser.parse_failed for undefined input', () => {
-    const parser = new BooleanParser()
+      parser.parse(null);
+    }).toThrow(LlmExeError);
+  });
+  it("throws parser.parse_failed for undefined input", () => {
+    const parser = new BooleanParser();
     expect(() => {
       // @ts-expect-error runtime contract: parser rejects undefined input.
-      parser.parse(undefined)
-    }).toThrow(LlmExeError)
-  })
+      parser.parse(undefined);
+    }).toThrow(LlmExeError);
+  });
 });

--- a/src/parser/parsers/BooleanParser.ts
+++ b/src/parser/parsers/BooleanParser.ts
@@ -6,22 +6,34 @@ const BOOLEAN_VALUES = ["true", "false", "yes", "no", "y", "n", "1", "0"];
 const TRUTHY_VALUES = new Set(["true", "yes", "y", "1"]);
 const FALSY_VALUES = new Set(["false", "no", "n", "0"]);
 const MAX_ERROR_INPUT_EXCERPT_LENGTH = 500;
+const BOOLEAN_TOKEN_PATTERN =
+  /(?<![\p{L}\p{N}])(?:true|false|yes|no|y|n|1|0)(?![\p{L}\p{N}])/giu;
+
+export type BooleanParserMatch = "exact" | "extract";
+
+export interface BooleanParserOptions {
+  match?: BooleanParserMatch;
+}
 
 /**
  * v3 parser contract:
  * Category: strict
- * Mode: whole-output
+ * Mode: exact
  *
  * Accepts only documented boolean literals after trim/lowercase.
- * Returns true/false only when input is recognized.
- * Throws LlmExeError(parser.parse_failed) for empty, invalid-type, or
- * unrecognized input. Does not extract booleans from prose.
+ * Returns true/false only when input is recognized. Pass match: "extract" to
+ * extract one documented boolean literal from surrounding text.
+ * Throws LlmExeError(parser.parse_failed) for empty or unrecognized input.
+ * Invalid input types throw LlmExeError(parser.invalid_input).
  * Error context does not include input content unless LLM_EXE_DEBUG is enabled.
  *
  */
 export class BooleanParser extends BaseParser<boolean> {
-  constructor() {
+  private match: BooleanParserMatch;
+
+  constructor(options?: BooleanParserOptions) {
     super("boolean");
+    this.match = options?.match ?? "exact";
   }
 
   private getInputErrorContext(text: string) {
@@ -57,7 +69,7 @@ export class BooleanParser extends BaseParser<boolean> {
             expected: "string",
             received: text === null ? "null" : typeof text,
           },
-        }
+        },
       );
     }
 
@@ -82,6 +94,39 @@ export class BooleanParser extends BaseParser<boolean> {
       return false;
     }
 
+    if (this.match === "extract") {
+      const matches = Array.from(
+        text.toLowerCase().matchAll(BOOLEAN_TOKEN_PATTERN),
+      ).map((match) => match[0]);
+      const values = Array.from(
+        new Set(
+          matches.map((match) => {
+            if (TRUTHY_VALUES.has(match)) return true;
+            return false;
+          }),
+        ),
+      );
+
+      if (values.length === 1) {
+        return values[0];
+      }
+
+      if (values.length > 1) {
+        throw new LlmExeError(`Multiple boolean values found in input.`, {
+          code: "parser.parse_failed",
+          context: {
+            operation: "BooleanParser.parse",
+            parser: "boolean",
+            reason: "ambiguous_boolean",
+            expected: "one boolean value",
+            match: this.match,
+            matchCount: values.length,
+            ...this.getInputErrorContext(text),
+          },
+        });
+      }
+    }
+
     throw new LlmExeError(`No boolean value found in input.`, {
       code: "parser.parse_failed",
       context: {
@@ -89,6 +134,7 @@ export class BooleanParser extends BaseParser<boolean> {
         parser: "boolean",
         reason: "unrecognized_boolean",
         expected: BOOLEAN_VALUES,
+        match: this.match,
         ...this.getInputErrorContext(text),
       },
     });

--- a/src/parser/parsers/JsonParser.test.ts
+++ b/src/parser/parsers/JsonParser.test.ts
@@ -1,4 +1,3 @@
-
 import { BaseParser, JsonParser } from "@/parser";
 import { defineSchema } from "@/utils/modules/defineSchema";
 import { LlmExeError } from "@/errors";
@@ -7,34 +6,34 @@ import { LlmExeError } from "@/errors";
  * Tests the JsonParser class
  */
 describe("llm-exe:parser/JsonParser", () => {
-  it('creates class with expected properties', () => {
-    const parser = new JsonParser()
-    expect(parser).toBeInstanceOf(BaseParser)
-    expect(parser).toBeInstanceOf(JsonParser)
-    expect(parser).toHaveProperty("name")
-    expect(parser.name).toEqual("json")
-  })
-  it('parses simple string correctly', () => {
-    const parser = new JsonParser()
-    const input = JSON.stringify({ name: "Greg", occupation: "developer"})
-    expect(parser.parse(input)).toEqual(JSON.parse(input))
+  it("creates class with expected properties", () => {
+    const parser = new JsonParser();
+    expect(parser).toBeInstanceOf(BaseParser);
+    expect(parser).toBeInstanceOf(JsonParser);
+    expect(parser).toHaveProperty("name");
+    expect(parser.name).toEqual("json");
   });
-  it('parses array JSON correctly', () => {
-    const parser = new JsonParser()
-    const input = JSON.stringify([{ name: "Greg" }])
-    expect(parser.parse(input)).toEqual(JSON.parse(input))
+  it("parses simple string correctly", () => {
+    const parser = new JsonParser();
+    const input = JSON.stringify({ name: "Greg", occupation: "developer" });
+    expect(parser.parse(input)).toEqual(JSON.parse(input));
   });
-  it('parses already-parsed plain object input', () => {
-    const parser = new JsonParser()
-    const input = { name: "Greg" }
-    expect(parser.parse(input as any)).toBe(input)
+  it("parses array JSON correctly", () => {
+    const parser = new JsonParser();
+    const input = JSON.stringify([{ name: "Greg" }]);
+    expect(parser.parse(input)).toEqual(JSON.parse(input));
   });
-  it('parses already-parsed array input', () => {
-    const parser = new JsonParser()
-    const input = [{ name: "Greg" }]
-    expect(parser.parse(input as any)).toBe(input)
+  it("parses already-parsed plain object input", () => {
+    const parser = new JsonParser();
+    const input = { name: "Greg" };
+    expect(parser.parse(input as any)).toBe(input);
   });
-  it('parses simple string correctly', () => {
+  it("parses already-parsed array input", () => {
+    const parser = new JsonParser();
+    const input = [{ name: "Greg" }];
+    expect(parser.parse(input as any)).toBe(input);
+  });
+  it("parses simple string correctly", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -44,13 +43,12 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["occupation", "name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
-    const input = JSON.stringify({ name: "Greg", occupation: "developer"})
-    expect(parser.parse(input)).toEqual(JSON.parse(input))
+    const parser = new JsonParser({ schema });
+    const input = JSON.stringify({ name: "Greg", occupation: "developer" });
+    expect(parser.parse(input)).toEqual(JSON.parse(input));
   });
 
-
-  it('parses simple string correctly', () => {
+  it("parses simple string correctly", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -60,12 +58,12 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["confused", "name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
-    const input = JSON.stringify({ name: "Greg", confused: true})
-    expect(parser.parse(input)).toEqual(JSON.parse(input))
+    const parser = new JsonParser({ schema });
+    const input = JSON.stringify({ name: "Greg", confused: true });
+    expect(parser.parse(input)).toEqual(JSON.parse(input));
   });
 
-  it('parses schema with error when set', () => {
+  it("parses schema with error when set", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -75,11 +73,13 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["occupation", "name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema, validateSchema: true })
-    const input = JSON.stringify({ name: "Greg", occupation: 0})
-    expect(() => parser.parse(input)).toThrowError("is not of a type(s) string")
+    const parser = new JsonParser({ schema, validateSchema: true });
+    const input = JSON.stringify({ name: "Greg", occupation: 0 });
+    expect(() => parser.parse(input)).toThrowError(
+      "is not of a type(s) string",
+    );
   });
-  it('validates schema by default when schema is provided', () => {
+  it("validates schema by default when schema is provided", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -88,20 +88,22 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
+    const parser = new JsonParser({ schema });
     try {
-      parser.parse(JSON.stringify({ age: 25 }))
-      fail("Expected an error to be thrown")
+      parser.parse(JSON.stringify({ age: 25 }));
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.schema_validation_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual(
+        "parser.schema_validation_failed",
+      );
       expect((e as LlmExeError).context).toMatchObject({
         operation: "JsonParser.parse",
         parser: "json",
-      })
+      });
     }
   });
-  it('preserves schema filter/default-only behavior when validateSchema is false', () => {
+  it("preserves schema filter/default-only behavior when validateSchema is false", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -110,10 +112,12 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema, validateSchema: false })
-    expect(parser.parse(JSON.stringify({ age: 25 }))).toEqual({ name: "unknown" })
+    const parser = new JsonParser({ schema, validateSchema: false });
+    expect(parser.parse(JSON.stringify({ age: 25 }))).toEqual({
+      name: "unknown",
+    });
   });
-  it('throws when a required field with a default is missing', () => {
+  it("throws when a required field with a default is missing", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -122,20 +126,22 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
-    expect(() => parser.parse("{}")).toThrow(LlmExeError)
+    const parser = new JsonParser({ schema });
+    expect(() => parser.parse("{}")).toThrow(LlmExeError);
     try {
-      parser.parse("{}")
-      fail("Expected an error to be thrown")
+      parser.parse("{}");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect((e as LlmExeError).code).toEqual("parser.schema_validation_failed")
+      expect((e as LlmExeError).code).toEqual(
+        "parser.schema_validation_failed",
+      );
       expect((e as LlmExeError).context).toMatchObject({
         operation: "JsonParser.parse",
         parser: "json",
-      })
+      });
     }
   });
-  it('throws when a required numeric field with a default is missing', () => {
+  it("throws when a required numeric field with a default is missing", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -144,10 +150,10 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["count"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
-    expect(() => parser.parse("{}")).toThrow(LlmExeError)
+    const parser = new JsonParser({ schema });
+    expect(() => parser.parse("{}")).toThrow(LlmExeError);
   });
-  it('does not coerce string values before schema validation', () => {
+  it("does not coerce string values before schema validation", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -157,12 +163,12 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["count", "active"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
+    const parser = new JsonParser({ schema });
     expect(() =>
-      parser.parse(JSON.stringify({ count: "42", active: "false" }))
-    ).toThrow(LlmExeError)
+      parser.parse(JSON.stringify({ count: "42", active: "false" })),
+    ).toThrow(LlmExeError);
   });
-  it('rejects additional properties before filtering when additionalProperties is false', () => {
+  it("rejects additional properties before filtering when additionalProperties is false", () => {
     const schema = defineSchema({
       type: "object",
       properties: {
@@ -171,12 +177,12 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["name"],
       additionalProperties: false,
     });
-    const parser = new JsonParser({ schema })
+    const parser = new JsonParser({ schema });
     expect(() =>
-      parser.parse(JSON.stringify({ name: "Greg", age: 25 }))
-    ).toThrow(LlmExeError)
+      parser.parse(JSON.stringify({ name: "Greg", age: 25 })),
+    ).toThrow(LlmExeError);
   });
-  it('preserves additional properties when schema allows them', () => {
+  it("preserves additional properties when schema allows them", () => {
     const schema = {
       type: "object",
       properties: {
@@ -185,13 +191,13 @@ describe("llm-exe:parser/JsonParser", () => {
       required: ["name"],
       additionalProperties: true,
     } as const;
-    const parser = new JsonParser({ schema })
+    const parser = new JsonParser({ schema });
     expect(parser.parse(JSON.stringify({ name: "Greg", age: 25 }))).toEqual({
       name: "Greg",
       age: 25,
-    })
+    });
   });
-  it('preserves additional properties when additionalProperties is omitted', () => {
+  it("preserves additional properties when additionalProperties is omitted", () => {
     const schema = {
       type: "object",
       properties: {
@@ -199,53 +205,53 @@ describe("llm-exe:parser/JsonParser", () => {
       },
       required: ["name"],
     } as const;
-    const parser = new JsonParser({ schema })
+    const parser = new JsonParser({ schema });
     expect(parser.parse(JSON.stringify({ name: "Greg", age: 25 }))).toEqual({
       name: "Greg",
       age: 25,
-    })
+    });
   });
-  it('throws parser.parse_failed for invalid JSON', () => {
-    const parser = new JsonParser()
+  it("throws parser.parse_failed for invalid JSON", () => {
+    const parser = new JsonParser();
     try {
-      parser.parse("This is not JSON at all")
-      fail("Expected an error to be thrown")
+      parser.parse("This is not JSON at all");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toEqual({
         operation: "JsonParser.parse",
         parser: "json",
         reason: "invalid_json",
         expected: "JSON object or array",
         inputLength: 23,
-      })
-      expect((e as any).cause).toBeInstanceOf(SyntaxError)
+      });
+      expect((e as any).cause).toBeInstanceOf(SyntaxError);
     }
   });
-  it('throws parser.parse_failed for empty input', () => {
-    const parser = new JsonParser()
+  it("throws parser.parse_failed for empty input", () => {
+    const parser = new JsonParser();
     try {
-      parser.parse("")
-      fail("Expected an error to be thrown")
+      parser.parse("");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toEqual({
         operation: "JsonParser.parse",
         parser: "json",
         reason: "empty_input",
         expected: "JSON object or array",
         inputLength: 0,
-      })
+      });
     }
   });
-  it('throws parser.parse_failed for JSON primitives', () => {
-    const parser = new JsonParser()
+  it("throws parser.parse_failed for JSON primitives", () => {
+    const parser = new JsonParser();
     try {
-      parser.parse("42")
-      fail("Expected an error to be thrown")
+      parser.parse("42");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toEqual({
         operation: "JsonParser.parse",
         parser: "json",
@@ -253,59 +259,139 @@ describe("llm-exe:parser/JsonParser", () => {
         expected: "JSON object or array",
         received: "number",
         inputLength: 2,
-      })
+      });
     }
   });
-  it('throws parser.parse_failed for JSON null root', () => {
-    const parser = new JsonParser()
+  it("throws parser.parse_failed for JSON null root", () => {
+    const parser = new JsonParser();
     try {
-      parser.parse("null")
-      fail("Expected an error to be thrown")
+      parser.parse("null");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toMatchObject({
         operation: "JsonParser.parse",
         parser: "json",
         reason: "invalid_json_root_type",
         received: "null",
-      })
+      });
     }
   });
-  it('parses whole-response json fences case-insensitively', () => {
-    const parser = new JsonParser()
-    expect(parser.parse("```JSON\n{\"name\":\"Greg\"}\n```")).toEqual({ name: "Greg" })
-    expect(parser.parse("```\n[{\"name\":\"Greg\"}]\n```")).toEqual([{ name: "Greg" }])
+  it("parses exact-response json fences case-insensitively", () => {
+    const parser = new JsonParser();
+    expect(parser.parse('```JSON\n{"name":"Greg"}\n```')).toEqual({
+      name: "Greg",
+    });
+    expect(parser.parse('```\n[{"name":"Greg"}]\n```')).toEqual([
+      { name: "Greg" },
+    ]);
   });
-  it('does not extract fenced JSON from prose', () => {
-    const parser = new JsonParser()
-    expect(() => parser.parse("Here is JSON:\n```json\n{\"name\":\"Greg\"}\n```")).toThrow(LlmExeError)
+  it("does not extract fenced JSON from prose", () => {
+    const parser = new JsonParser();
+    expect(() =>
+      parser.parse('Here is JSON:\n```json\n{"name":"Greg"}\n```'),
+    ).toThrow(LlmExeError);
   });
-  it('rejects whole-response non-json fenced blocks as invalid JSON', () => {
-    const parser = new JsonParser()
+  describe("match: extract", () => {
+    it("extracts a JSON object from surrounding text", () => {
+      const parser = new JsonParser({ match: "extract" });
+      expect(parser.parse('Here is JSON: {"name":"Greg"}')).toEqual({
+        name: "Greg",
+      });
+    });
+    it("extracts a JSON array from surrounding text", () => {
+      const parser = new JsonParser({ match: "extract" });
+      expect(parser.parse('Results: [{"name":"Greg"}]')).toEqual([
+        { name: "Greg" },
+      ]);
+    });
+    it("extracts fenced JSON from surrounding text", () => {
+      const parser = new JsonParser({ match: "extract" });
+      expect(
+        parser.parse('Here is JSON:\n```json\n{"name":"Greg"}\n```'),
+      ).toEqual({ name: "Greg" });
+    });
+    it("keeps nested objects and arrays as one match", () => {
+      const parser = new JsonParser({ match: "extract" });
+      expect(parser.parse('Result: {"outer":{"inner":[{"x":1}]}}')).toEqual({
+        outer: { inner: [{ x: 1 }] },
+      });
+    });
+    it("throws when multiple JSON values are found", () => {
+      const parser = new JsonParser({ match: "extract" });
+      try {
+        parser.parse('First: {"a":1}. Second: {"b":2}.');
+        fail("Expected an error to be thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(LlmExeError);
+        expect((e as LlmExeError).context).toMatchObject({
+          reason: "ambiguous_json_match",
+          expected: "one JSON object or array",
+          match: "extract",
+          matchCount: 2,
+        });
+      }
+    });
+    it("throws when no JSON value is found", () => {
+      const parser = new JsonParser({ match: "extract" });
+      try {
+        parser.parse("not json");
+        fail("Expected an error to be thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(LlmExeError);
+        expect((e as LlmExeError).context).toMatchObject({
+          reason: "no_json_value",
+          expected: "JSON object or array",
+          match: "extract",
+        });
+      }
+    });
+    it("validates schema after extraction", () => {
+      const schema = defineSchema({
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+        required: ["name"],
+        additionalProperties: false,
+      });
+      const parser = new JsonParser({ schema, match: "extract" });
+      expect(parser.parse('Here is JSON: {"name":"Greg"}')).toEqual({
+        name: "Greg",
+      });
+      expect(() => parser.parse('Here is JSON: {"age":25}')).toThrow(
+        LlmExeError,
+      );
+    });
+  });
+  it("rejects exact-response non-json fenced blocks as invalid JSON", () => {
+    const parser = new JsonParser();
     try {
-      parser.parse("```ts\n{\"name\":\"Greg\"}\n```")
-      fail("Expected an error to be thrown")
+      parser.parse('```ts\n{"name":"Greg"}\n```');
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
-      expect((e as LlmExeError).code).toEqual("parser.parse_failed")
+      expect(e).toBeInstanceOf(LlmExeError);
+      expect((e as LlmExeError).code).toEqual("parser.parse_failed");
       expect((e as LlmExeError).context).toMatchObject({
         operation: "JsonParser.parse",
         parser: "json",
         reason: "invalid_json",
-      })
-      expect((e as Error & { cause?: unknown }).cause).toBeInstanceOf(SyntaxError)
+      });
+      expect((e as Error & { cause?: unknown }).cause).toBeInstanceOf(
+        SyntaxError,
+      );
     }
   });
-  it('throws parser.parse_failed for runtime null', () => {
-    const parser = new JsonParser()
-    expect(() => parser.parse(null as any)).toThrow(LlmExeError)
+  it("throws parser.parse_failed for runtime null", () => {
+    const parser = new JsonParser();
+    expect(() => parser.parse(null as any)).toThrow(LlmExeError);
   });
-  it('throws parser.parse_failed for runtime class instances', () => {
+  it("throws parser.parse_failed for runtime class instances", () => {
     class Example {
       value = "x";
     }
-    const parser = new JsonParser()
-    expect(() => parser.parse(new Example() as any)).toThrow(LlmExeError)
+    const parser = new JsonParser();
+    expect(() => parser.parse(new Example() as any)).toThrow(LlmExeError);
   });
 
   describe("nested and array structures", () => {
@@ -357,9 +443,9 @@ describe("llm-exe:parser/JsonParser", () => {
         additionalProperties: false,
       });
       const parser = new JsonParser({ schema, validateSchema: true });
-      expect(() =>
-        parser.parse(JSON.stringify({ name: "Greg" }))
-      ).toThrowError(/age/);
+      expect(() => parser.parse(JSON.stringify({ name: "Greg" }))).toThrowError(
+        /age/,
+      );
     });
 
     it("throws with first error message when multiple validation errors exist", () => {
@@ -375,9 +461,8 @@ describe("llm-exe:parser/JsonParser", () => {
       const parser = new JsonParser({ schema, validateSchema: true });
       // Both fields invalid — should throw on the first one
       expect(() =>
-        parser.parse(JSON.stringify({ name: 42, age: "old" }))
+        parser.parse(JSON.stringify({ name: 42, age: "old" })),
       ).toThrow();
     });
   });
-
 });

--- a/src/parser/parsers/JsonParser.ts
+++ b/src/parser/parsers/JsonParser.ts
@@ -12,6 +12,9 @@ export type JsonParserInput = string | Record<string, unknown> | unknown[];
 type JsonParserOutput<S extends JSONSchema | undefined> = S extends JSONSchema
   ? FromSchema<S>
   : Record<string, any>;
+type JsonCandidate = {
+  parsed: unknown;
+};
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -22,9 +25,11 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
-function normalizeWholeResponseJsonText(input: string) {
+function normalizeExactResponseJsonText(input: string) {
   const trimmed = input.trim();
-  const fenceMatch = trimmed.match(/^```([a-zA-Z]*)[^\S\r\n]*\r?\n([\s\S]*)```$/);
+  const fenceMatch = trimmed.match(
+    /^```([a-zA-Z]*)[^\S\r\n]*\r?\n([\s\S]*)```$/,
+  );
 
   if (!fenceMatch) {
     return trimmed;
@@ -38,30 +43,109 @@ function normalizeWholeResponseJsonText(input: string) {
   return body.trim();
 }
 
+function findBalancedJsonEnd(input: string, start: number) {
+  const first = input[start];
+  const stack = first === "{" ? ["}"] : first === "[" ? ["]"] : [];
+  let inString = false;
+  let escaping = false;
+
+  for (let index = start + 1; index < input.length; index += 1) {
+    const char = input[index];
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{" || char === "[") {
+      stack.push(char === "{" ? "}" : "]");
+      continue;
+    }
+
+    if (char !== "}" && char !== "]") {
+      continue;
+    }
+
+    if (stack[stack.length - 1] !== char) {
+      return undefined;
+    }
+
+    stack.pop();
+    if (stack.length === 0) {
+      return index;
+    }
+  }
+
+  return undefined;
+}
+
+function extractJsonCandidates(input: string): JsonCandidate[] {
+  const candidates: JsonCandidate[] = [];
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (char !== "{" && char !== "[") {
+      continue;
+    }
+
+    const end = findBalancedJsonEnd(input, index);
+    if (end === undefined) {
+      continue;
+    }
+
+    const candidate = input.slice(index, end + 1);
+    try {
+      candidates.push({
+        parsed: JSON.parse(candidate),
+      });
+      index = end;
+    } catch {
+      // Balanced braces can still contain non-JSON content.
+    }
+  }
+
+  return candidates;
+}
+
 export class JsonParser<
-  S extends JSONSchema | undefined = undefined
+  S extends JSONSchema | undefined = undefined,
 > extends BaseParserWithJson<S, JsonParserOutput<S>, JsonParserInput> {
   private shouldValidateSchema: boolean;
+  private match: JsonParserOptions<S>["match"];
 
   constructor(options: JsonParserOptions<S> = {}) {
     super("json", options);
-    this.shouldValidateSchema = !!options.schema && options.validateSchema !== false;
+    this.match = options.match ?? "exact";
+    this.shouldValidateSchema =
+      !!options.schema && options.validateSchema !== false;
   }
 
   /**
    * v3 parser contract:
    * Category: strict
-   * Mode: whole-output
+   * Mode: exact
    *
-   * Parses strict JSON object/array output only. Invalid JSON, empty input,
-   * JSON primitives, and non-plain runtime objects throw typed parser errors.
+   * Parses strict JSON object/array output by default. Pass match: "extract"
+   * to extract one JSON object or array from surrounding text. Invalid JSON,
+   * empty input, JSON primitives, and non-plain runtime objects throw typed parser errors.
    * Schema validation is on by default when a schema is provided unless
    * validateSchema: false is explicitly set.
    *
    */
   parse(
     text: JsonParserInput,
-    _attributes?: Record<string, any>
+    _attributes?: Record<string, any>,
   ): JsonParserOutput<S> {
     let parsed: unknown;
     let inputLength: number | undefined;
@@ -82,19 +166,53 @@ export class JsonParser<
       }
 
       try {
-        parsed = JSON.parse(normalizeWholeResponseJsonText(text));
+        parsed = JSON.parse(normalizeExactResponseJsonText(text));
       } catch (cause) {
-        throw new LlmExeError(`Invalid JSON input.`, {
-          code: "parser.parse_failed",
-          context: {
-            operation: "JsonParser.parse",
-            parser: "json",
-            reason: "invalid_json",
-            expected: "JSON object or array",
-            inputLength,
-          },
-          cause,
-        });
+        if (this.match === "extract") {
+          const candidates = extractJsonCandidates(text);
+
+          if (candidates.length === 1) {
+            parsed = candidates[0].parsed;
+          } else if (candidates.length > 1) {
+            throw new LlmExeError(`Multiple JSON values found in input.`, {
+              code: "parser.parse_failed",
+              context: {
+                operation: "JsonParser.parse",
+                parser: "json",
+                reason: "ambiguous_json_match",
+                expected: "one JSON object or array",
+                match: this.match,
+                inputLength,
+                matchCount: candidates.length,
+              },
+            });
+          } else {
+            throw new LlmExeError(`No JSON value found in input.`, {
+              code: "parser.parse_failed",
+              context: {
+                operation: "JsonParser.parse",
+                parser: "json",
+                reason: "no_json_value",
+                expected: "JSON object or array",
+                match: this.match,
+                inputLength,
+              },
+              cause,
+            });
+          }
+        } else {
+          throw new LlmExeError(`Invalid JSON input.`, {
+            code: "parser.parse_failed",
+            context: {
+              operation: "JsonParser.parse",
+              parser: "json",
+              reason: "invalid_json",
+              expected: "JSON object or array",
+              inputLength,
+            },
+            cause,
+          });
+        }
       }
     } else if (Array.isArray(text) || isPlainObject(text)) {
       parsed = text;
@@ -110,7 +228,7 @@ export class JsonParser<
             expected: "JSON string, plain object, or array",
             received: text === null ? "null" : typeof text,
           },
-        }
+        },
       );
     }
 
@@ -145,7 +263,7 @@ export class JsonParser<
       if (this.shouldValidateSchema) {
         return applyParserSchemaDefaultsAndFilter(
           this.schema,
-          parsed
+          parsed,
         ) as JsonParserOutput<S>;
       }
       return enforceParserSchema(this.schema, parsed) as JsonParserOutput<S>;

--- a/src/parser/parsers/NumberParser.test.ts
+++ b/src/parser/parsers/NumberParser.test.ts
@@ -5,65 +5,65 @@ import { LlmExeError } from "@/errors";
  * Tests the NumberParser class
  */
 describe("llm-exe:parser/NumberParser", () => {
-  it('creates class with expected properties', () => {
-    const parser = new NumberParser()
-    expect(parser).toBeInstanceOf(BaseParser)
-    expect(parser).toBeInstanceOf(NumberParser)
-    expect(parser).toHaveProperty("name")
-    expect(parser.name).toEqual("number")
-  })
-  it('parses simple string correctly', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("1")).toEqual(1)
+  it("creates class with expected properties", () => {
+    const parser = new NumberParser();
+    expect(parser).toBeInstanceOf(BaseParser);
+    expect(parser).toBeInstanceOf(NumberParser);
+    expect(parser).toHaveProperty("name");
+    expect(parser.name).toEqual("number");
   });
-  it('parses multi-digit numbers', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("42")).toEqual(42)
-    expect(parser.parse("100")).toEqual(100)
-    expect(parser.parse("1234567")).toEqual(1234567)
+  it("parses simple string correctly", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("1")).toEqual(1);
   });
-  it('parses decimal numbers', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("3.14")).toEqual(3.14)
-    expect(parser.parse("0.5")).toEqual(0.5)
+  it("parses multi-digit numbers", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("42")).toEqual(42);
+    expect(parser.parse("100")).toEqual(100);
+    expect(parser.parse("1234567")).toEqual(1234567);
   });
-  it('parses comma numbers', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("1,000")).toEqual(1000)
-    expect(parser.parse("1,234,567")).toEqual(1234567)
+  it("parses decimal numbers", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("3.14")).toEqual(3.14);
+    expect(parser.parse("0.5")).toEqual(0.5);
   });
-  it('parses scientific notation', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("1e3")).toEqual(1000)
-    expect(parser.parse("-2.5e2")).toEqual(-250)
-    expect(parser.parse("1.5e10")).toEqual(15000000000)
+  it("parses comma numbers", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("1,000")).toEqual(1000);
+    expect(parser.parse("1,234,567")).toEqual(1234567);
   });
-  it('parses leading decimals', () => {
-    const parser = new NumberParser()
-    expect(parser.parse(".5")).toEqual(0.5)
-    expect(parser.parse("-.25")).toEqual(-0.25)
+  it("parses scientific notation", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("1e3")).toEqual(1000);
+    expect(parser.parse("-2.5e2")).toEqual(-250);
+    expect(parser.parse("1.5e10")).toEqual(15000000000);
   });
-  it('parses negative numbers', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("-7")).toEqual(-7)
-    expect(parser.parse("-3.14")).toEqual(-3.14)
-    expect(parser.parse("-1")).toEqual(-1)
+  it("parses leading decimals", () => {
+    const parser = new NumberParser();
+    expect(parser.parse(".5")).toEqual(0.5);
+    expect(parser.parse("-.25")).toEqual(-0.25);
   });
-  it('parses negative one from surrounding text', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("the answer is -1")).toEqual(-1)
+  it("parses negative numbers", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("-7")).toEqual(-7);
+    expect(parser.parse("-3.14")).toEqual(-3.14);
+    expect(parser.parse("-1")).toEqual(-1);
   });
-  it('extracts number from surrounding text', () => {
-    const parser = new NumberParser()
-    expect(parser.parse("The answer is 42.")).toEqual(42)
-    expect(parser.parse("Score: 99 points")).toEqual(99)
+  it("parses negative one from surrounding text", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("the answer is -1")).toEqual(-1);
   });
-  it('throws LlmExeError if no number found', () => {
-    const parser = new NumberParser()
-    expect(() => parser.parse("No Number")).toThrow(LlmExeError)
+  it("extracts number from surrounding text", () => {
+    const parser = new NumberParser();
+    expect(parser.parse("The answer is 42.")).toEqual(42);
+    expect(parser.parse("Score: 99 points")).toEqual(99);
   });
-  it('throws LlmExeError with parser error code when no number found', () => {
-    const parser = new NumberParser()
+  it("throws LlmExeError if no number found", () => {
+    const parser = new NumberParser();
+    expect(() => parser.parse("No Number")).toThrow(LlmExeError);
+  });
+  it("throws LlmExeError with parser error code when no number found", () => {
+    const parser = new NumberParser();
     try {
       parser.parse("not a number");
       fail("Expected an error to be thrown");
@@ -80,8 +80,8 @@ describe("llm-exe:parser/NumberParser", () => {
       });
     }
   });
-  it('throws parser.parse_failed for empty input', () => {
-    const parser = new NumberParser()
+  it("throws parser.parse_failed for empty input", () => {
+    const parser = new NumberParser();
     try {
       parser.parse("");
       fail("Expected an error to be thrown");
@@ -96,12 +96,12 @@ describe("llm-exe:parser/NumberParser", () => {
       });
     }
   });
-  it('throws parser.parse_failed for whitespace-only input', () => {
-    const parser = new NumberParser()
-    expect(() => parser.parse("   ")).toThrow(LlmExeError)
+  it("throws parser.parse_failed for whitespace-only input", () => {
+    const parser = new NumberParser();
+    expect(() => parser.parse("   ")).toThrow(LlmExeError);
   });
-  it('throws parser.parse_failed for multiple numbers', () => {
-    const parser = new NumberParser()
+  it("throws parser.parse_failed for multiple numbers", () => {
+    const parser = new NumberParser();
     try {
       parser.parse("from 1 to 10");
       fail("Expected an error to be thrown");
@@ -118,21 +118,21 @@ describe("llm-exe:parser/NumberParser", () => {
       });
     }
   });
-  it('rejects Indian-style comma grouping instead of partially parsing it', () => {
-    const parser = new NumberParser()
+  it("rejects Indian-style comma grouping instead of partially parsing it", () => {
+    const parser = new NumberParser();
     try {
-      parser.parse("1,00,000")
-      fail("Expected an error to be thrown")
+      parser.parse("1,00,000");
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toMatchObject({
         reason: "no_numeric_value",
         match: "extract",
-      })
+      });
     }
   });
-  it('throws parser.parse_failed for runtime number input', () => {
-    const parser = new NumberParser()
+  it("throws parser.parse_failed for runtime number input", () => {
+    const parser = new NumberParser();
     try {
       // @ts-expect-error runtime contract: parser rejects non-string input.
       parser.parse(42);
@@ -148,72 +148,72 @@ describe("llm-exe:parser/NumberParser", () => {
       });
     }
   });
-  it('throws parser.parse_failed for null input', () => {
-    const parser = new NumberParser()
+  it("throws parser.parse_failed for null input", () => {
+    const parser = new NumberParser();
     expect(() => {
       // @ts-expect-error runtime contract: parser rejects null input.
-      parser.parse(null)
-    }).toThrow(LlmExeError)
+      parser.parse(null);
+    }).toThrow(LlmExeError);
   });
-  it('describes array invalid input type in parser context', () => {
-    const parser = new NumberParser()
+  it("describes array invalid input type in parser context", () => {
+    const parser = new NumberParser();
     try {
       // @ts-expect-error runtime contract: parser rejects array input.
-      parser.parse([])
-      fail("Expected an error to be thrown")
+      parser.parse([]);
+      fail("Expected an error to be thrown");
     } catch (e) {
-      expect(e).toBeInstanceOf(LlmExeError)
+      expect(e).toBeInstanceOf(LlmExeError);
       expect((e as LlmExeError).context).toMatchObject({
         operation: "NumberParser.parse",
         parser: "number",
         reason: "invalid_input_type",
         received: "array",
-      })
+      });
     }
   });
 
-  describe("match: whole", () => {
+  describe("match: exact", () => {
     it("accepts a bare integer", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(parser.parse("42")).toEqual(42)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(parser.parse("42")).toEqual(42);
+    });
     it("accepts a bare decimal", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(parser.parse("3.14")).toEqual(3.14)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(parser.parse("3.14")).toEqual(3.14);
+    });
     it("accepts a comma-grouped number", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(parser.parse("1,000")).toEqual(1000)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(parser.parse("1,000")).toEqual(1000);
+    });
     it("accepts a value after trim", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(parser.parse("  42  ")).toEqual(42)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(parser.parse("  42  ")).toEqual(42);
+    });
     it("rejects a number embedded in prose", () => {
-      const parser = new NumberParser({ match: "whole" })
+      const parser = new NumberParser({ match: "exact" });
       try {
-        parser.parse("The answer is 42.")
-        fail("Expected an error to be thrown")
+        parser.parse("The answer is 42.");
+        fail("Expected an error to be thrown");
       } catch (e) {
-        expect(e).toBeInstanceOf(LlmExeError)
+        expect(e).toBeInstanceOf(LlmExeError);
         expect((e as LlmExeError).context).toMatchObject({
           reason: "no_numeric_value",
-          match: "whole",
-        })
+          match: "exact",
+        });
       }
-    })
+    });
     it("rejects multiple numbers", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(() => parser.parse("1 2")).toThrow(LlmExeError)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(() => parser.parse("1 2")).toThrow(LlmExeError);
+    });
     it("rejects currency and unit text", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(() => parser.parse("$5")).toThrow(LlmExeError)
-      expect(() => parser.parse("5 dollars")).toThrow(LlmExeError)
-    })
+      const parser = new NumberParser({ match: "exact" });
+      expect(() => parser.parse("$5")).toThrow(LlmExeError);
+      expect(() => parser.parse("5 dollars")).toThrow(LlmExeError);
+    });
     it("rejects invalid comma grouping", () => {
-      const parser = new NumberParser({ match: "whole" })
-      expect(() => parser.parse("1,00,000")).toThrow(LlmExeError)
-    })
-  })
+      const parser = new NumberParser({ match: "exact" });
+      expect(() => parser.parse("1,00,000")).toThrow(LlmExeError);
+    });
+  });
 });

--- a/src/parser/parsers/NumberParser.ts
+++ b/src/parser/parsers/NumberParser.ts
@@ -3,7 +3,7 @@ import { isFinite } from "@/utils/modules/isFinite";
 import { toNumber } from "@/utils/modules/toNumber";
 import { LlmExeError } from "@/errors";
 
-export type NumberParserMatch = "extract" | "whole";
+export type NumberParserMatch = "exact" | "extract";
 
 export interface NumberParserOptions {
   match?: NumberParserMatch;
@@ -11,7 +11,7 @@ export interface NumberParserOptions {
 
 const NUMERIC_TOKEN_PATTERN =
   /(^|[^\w.,])([+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)(?![\w,])/g;
-const WHOLE_NUMERIC_PATTERN =
+const EXACT_NUMERIC_PATTERN =
   /^[+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 /**
@@ -19,7 +19,7 @@ const WHOLE_NUMERIC_PATTERN =
  * Category: extractor
  * Mode: numeric token extraction
  *
- * Extracts one documented numeric token from text. Pass match: "whole" to
+ * Extracts one documented numeric token from text. Pass match: "exact" to
  * require the input to consist of exactly one numeric token (after trim) with
  * no surrounding prose.
  *
@@ -46,9 +46,14 @@ export class NumberParser extends BaseParser<number> {
             parser: "number",
             reason: "invalid_input_type",
             expected: "string",
-            received: text === null ? "null" : Array.isArray(text) ? "array" : typeof text,
+            received:
+              text === null
+                ? "null"
+                : Array.isArray(text)
+                  ? "array"
+                  : typeof text,
           },
-        }
+        },
       );
     }
 
@@ -65,16 +70,16 @@ export class NumberParser extends BaseParser<number> {
       });
     }
 
-    if (this.match === "whole") {
+    if (this.match === "exact") {
       const trimmed = text.trim();
-      if (!WHOLE_NUMERIC_PATTERN.test(trimmed)) {
-        throw new LlmExeError(`Input is not a whole numeric value.`, {
+      if (!EXACT_NUMERIC_PATTERN.test(trimmed)) {
+        throw new LlmExeError(`Input is not an exact numeric value.`, {
           code: "parser.parse_failed",
           context: {
             operation: "NumberParser.parse",
             parser: "number",
             reason: "no_numeric_value",
-            expected: "whole number",
+            expected: "exact number",
             match: this.match,
             inputLength: text.length,
           },
@@ -82,7 +87,7 @@ export class NumberParser extends BaseParser<number> {
       }
 
       const value = toNumber(trimmed.replace(/,/g, ""));
-      /* istanbul ignore next -- WHOLE_NUMERIC_PATTERN only accepts finite Number-compatible tokens; this guard is defensive if the pattern changes. */
+      /* istanbul ignore next -- EXACT_NUMERIC_PATTERN only accepts finite Number-compatible tokens; this guard is defensive if the pattern changes. */
       if (!isFinite(value)) {
         throw new LlmExeError(`Invalid numeric value found in input.`, {
           code: "parser.parse_failed",
@@ -100,7 +105,7 @@ export class NumberParser extends BaseParser<number> {
     }
 
     const matches = Array.from(text.matchAll(NUMERIC_TOKEN_PATTERN)).map(
-      (match) => match[2]
+      (match) => match[2],
     );
 
     if (matches.length === 0) {

--- a/src/parser/parsers/StringExtractParser.test.ts
+++ b/src/parser/parsers/StringExtractParser.test.ts
@@ -70,7 +70,7 @@ describe("llm-exe:parser/StringExtractParser", () => {
     const parser = new StringExtractParser({ enum: ["Hello"] });
     expect(() => parser.parse("Yo!!")).toThrow(LlmExeError);
     expect(() => parser.parse("Yo!!")).toThrow(
-      "No matching enum value found in input."
+      "No matching enum value found in input.",
     );
   });
 
@@ -78,14 +78,14 @@ describe("llm-exe:parser/StringExtractParser", () => {
     const parser = new StringExtractParser({ enum: ["Hello"] });
     const badValue = ["Hello"] as unknown as string;
     expect(() => parser.parse(badValue)).toThrow(
-      "Invalid input. Expected string. Received array."
+      "Invalid input. Expected string. Received array.",
     );
   });
 
   it("throws for null input", () => {
     const parser = new StringExtractParser({ enum: ["Hello"] });
     expect(() => parser.parse(null as any)).toThrow(
-      "Invalid input. Expected string. Received null."
+      "Invalid input. Expected string. Received null.",
     );
   });
 
@@ -93,7 +93,7 @@ describe("llm-exe:parser/StringExtractParser", () => {
     const parser = new StringExtractParser({ enum: ["Hello"] });
     const badValue = { hello: "world" } as unknown as string;
     expect(() => parser.parse(badValue)).toThrow(
-      "Invalid input. Expected string. Received object."
+      "Invalid input. Expected string. Received object.",
     );
   });
 
@@ -281,11 +281,11 @@ describe("llm-exe:parser/StringExtractParser", () => {
     });
   });
 
-  describe("match: whole", () => {
+  describe("match: exact", () => {
     it("accepts input that equals the enum value", () => {
       const parser = new StringExtractParser({
         enum: ["yes", "no"],
-        match: "whole",
+        match: "exact",
       });
       expect(parser.parse("yes")).toEqual("yes");
     });
@@ -293,7 +293,7 @@ describe("llm-exe:parser/StringExtractParser", () => {
     it("accepts input after trimming whitespace", () => {
       const parser = new StringExtractParser({
         enum: ["yes"],
-        match: "whole",
+        match: "exact",
       });
       expect(parser.parse("  yes  ")).toEqual("yes");
     });
@@ -301,7 +301,7 @@ describe("llm-exe:parser/StringExtractParser", () => {
     it("rejects input that contains the value with extra content", () => {
       const parser = new StringExtractParser({
         enum: ["yes"],
-        match: "whole",
+        match: "exact",
       });
       try {
         parser.parse("yes please");
@@ -309,23 +309,23 @@ describe("llm-exe:parser/StringExtractParser", () => {
       } catch (e) {
         expect((e as LlmExeError).context).toMatchObject({
           reason: "no_enum_match",
-          match: "whole",
+          match: "exact",
         });
       }
     });
 
-    it("does not let empty enum value match in whole mode", () => {
+    it("does not let empty enum value match in exact mode", () => {
       const parser = new StringExtractParser({
         enum: ["", "yes"],
-        match: "whole",
+        match: "exact",
       });
       expect(parser.parse("yes")).toEqual("yes");
     });
 
-    it("respects ignoreCase: false in whole mode", () => {
+    it("respects ignoreCase: false in exact mode", () => {
       const parser = new StringExtractParser({
         enum: ["Yes"],
-        match: "whole",
+        match: "exact",
         ignoreCase: false,
       });
       expect(parser.parse("Yes")).toEqual("Yes");
@@ -373,27 +373,27 @@ describe("llm-exe:parser/StringExtractParser", () => {
       const parser = new StringExtractParser({ enum: ["a"] });
       const badValue = null as unknown as string;
       expect(() => parser.parse(badValue)).toThrow(
-        "Invalid input. Expected string. Received null."
+        "Invalid input. Expected string. Received null.",
       );
     });
 
-    it('throws on undefined input', () => {
+    it("throws on undefined input", () => {
       const parser = new StringExtractParser({ enum: ["a"] });
       const badValue = undefined as unknown as string;
       expect(() => parser.parse(badValue)).toThrow(
-        "Invalid input. Expected string. Received undefined."
+        "Invalid input. Expected string. Received undefined.",
       );
     });
 
-    it('throws on number input', () => {
+    it("throws on number input", () => {
       const parser = new StringExtractParser({ enum: ["a"] });
       const badValue = 42 as unknown as string;
       expect(() => parser.parse(badValue)).toThrow(
-        "Invalid input. Expected string. Received number."
+        "Invalid input. Expected string. Received number.",
       );
     });
 
-    it('throws on empty input when enum values exist', () => {
+    it("throws on empty input when enum values exist", () => {
       const parser = new StringExtractParser({ enum: ["yes"] });
       expect(() => parser.parse("")).toThrow(LlmExeError);
     });

--- a/src/parser/parsers/StringExtractParser.ts
+++ b/src/parser/parsers/StringExtractParser.ts
@@ -1,7 +1,7 @@
 import { BaseParser } from "../_base";
 import { LlmExeError } from "@/errors";
 
-export type StringExtractMatch = "word" | "whole" | "substring";
+export type StringExtractMatch = "exact" | "word" | "substring";
 
 export interface StringExtractParserOptions<
   E extends readonly string[] = readonly string[],
@@ -46,7 +46,7 @@ export class StringExtractParser<
    * Mode: configured value extraction
    *
    * Returns the single configured enum value found in input. Matching is
-   * word-bounded by default; pass match: "whole" to require exact input or
+   * word-bounded by default; pass match: "exact" to require exact input or
    * match: "substring" for legacy contains() behavior. Case-insensitive by
    * default.
    *
@@ -65,7 +65,7 @@ export class StringExtractParser<
             expected: "string",
             received,
           },
-        }
+        },
       );
     }
 
@@ -136,8 +136,8 @@ export class StringExtractParser<
 
   private findMatches(text: string): string[] {
     switch (this.match) {
-      case "whole":
-        return this.matchWhole(text);
+      case "exact":
+        return this.matchExact(text);
       case "substring":
         return this.matchSubstring(text);
       case "word":
@@ -146,7 +146,7 @@ export class StringExtractParser<
     }
   }
 
-  private matchWhole(text: string): string[] {
+  private matchExact(text: string): string[] {
     const candidate = this.ignoreCase ? text.trim().toLowerCase() : text.trim();
     return this.enum.filter((option) => {
       if (option === "") return false;
@@ -170,7 +170,7 @@ export class StringExtractParser<
       if (option === "") return false;
       const pattern = new RegExp(
         `(?<!${WORD_CHAR})${escapeRegex(option)}(?!${WORD_CHAR})`,
-        flags
+        flags,
       );
       return pattern.test(text);
     });


### PR DESCRIPTION
 - json: added match: "exact" | "extract", default exact; extract fi)nds one JSON object/array and fails on ambiguity.
 - boolean: added match: "exact" | "extract", default exact; extract finds one boolean value and fails on conflicting truthy/falsy values.
 - number: renamed match: "whole" to match: "exact".
 - stringExtract: renamed match: "whole" to match: "exact"; kept word | substring | exact.
 - Updated createParser(...) typing/wiring and exported the new option/match types.
 - Updated parser tests, scenario test title, README, parser docs, migration guide, generated llms.txt/llms-full.txt, and the working-doc release/migration drafts.
