### PR TITLE
Update setup-node to v6, refactor caching strategy, and bump agent runtime to Node 24

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,16 +1,8 @@
-name: 'Cache npm dependencies and node modules'
-description: 'Cache npm dependencies and node modules'
+name: 'Cache node modules'
+description: 'Cache node_modules directory. npm global cache (~/.npm) is handled by actions/setup-node cache: npm.'
 runs:
   using: 'composite'
   steps:
-    - name: Cache npm dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ matrix.node-version }}-
-
     - name: Cache node modules
       uses: actions/cache@v4
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,7 +3,8 @@ description: "Setup Node.js environment"
 runs:
   using: "composite"
   steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.x
+          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/docs/AGENT_REVIEW_PR_DEEP_DIVE.md
+++ b/.github/docs/AGENT_REVIEW_PR_DEEP_DIVE.md
@@ -241,7 +241,7 @@ sequenceDiagram
     J->>T: create-github-app-token@v1 (LLM_EXE_REVIEW_BOT_APP_ID, key)
     T-->>J: review bot token (short-lived)
     J->>G: checkout fetch-depth 0 with review bot token
-    J->>N: setup-node@v4 + npm ci
+    J->>N: setup-node@v6 + npm ci
     J->>C: source scripts/agents/config.sh
     C->>L: clock_in "reviewer" "PR #N" writes skeleton .md
     L-->>C: log file path
@@ -365,7 +365,7 @@ flowchart LR
     subgraph Pre["Before the reviewer starts"]
         c1["actions/create-github-app-token@v1\nauth: LLM_EXE_REVIEW_BOT_APP_ID + key\nwhy: review bot identity to post reviews"]:::pre
         c2["actions/checkout@v4\nauth: review bot token\nwhy: full history (depth 0)"]:::pre
-        c3["actions/setup-node@v4\nauth: none\nwhy: prime npm cache (used by tools)"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: prime npm cache (used by tools)"]:::pre
     end
 
     subgraph During["While the reviewer runs"]

--- a/.github/docs/AGENT_REVIEW_PR_DEEP_DIVE.md
+++ b/.github/docs/AGENT_REVIEW_PR_DEEP_DIVE.md
@@ -189,7 +189,7 @@ flowchart TB
         direction TB
         s1["Generate review bot token"]:::step
         s2["Checkout (fetch-depth: 0)"]:::step
-        s3["Setup Node 20"]:::step
+        s3["Setup Node 24"]:::step
         s4["npm ci"]:::step
         s5["Build review prompt\nclock_in + perl substitution"]:::step
         s6["Review PR\nclaude-code-action@v1\n(max-turns 30)"]:::step

--- a/.github/docs/AGENT_RUN_DEEP_DIVE.md
+++ b/.github/docs/AGENT_RUN_DEEP_DIVE.md
@@ -222,7 +222,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth: 0\nwith bot token"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
+        r4["actions/setup-node@v6\nnode-version: 24, cache: npm"]:::step
         r5["npm ci"]:::step
         r6["Pick agent for scheduled runs\n(only if event_name=schedule)"]:::step
         r7["Build prompt step\n(branch, log, prompt assembly)"]:::step
@@ -390,7 +390,7 @@ flowchart LR
     subgraph Pre["Before the agent starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: bot identity so writes trigger downstream"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: fetch full history (depth 0) for git operations"]:::pre
-        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 20, prime npm cache"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 24, prime npm cache"]:::pre
     end
 
     subgraph During["While the agent runs"]

--- a/.github/docs/AGENT_RUN_DEEP_DIVE.md
+++ b/.github/docs/AGENT_RUN_DEEP_DIVE.md
@@ -222,7 +222,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth: 0\nwith bot token"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["actions/setup-node@v4\nnode-version: 20, cache: npm"]:::step
+        r4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
         r5["npm ci"]:::step
         r6["Pick agent for scheduled runs\n(only if event_name=schedule)"]:::step
         r7["Build prompt step\n(branch, log, prompt assembly)"]:::step
@@ -262,7 +262,7 @@ sequenceDiagram
     T-->>J: bot token (short-lived)
     J->>G: checkout fetch-depth 0 with bot token
     J->>G: git config llm-exe-bot[bot]
-    J->>N: setup-node@v4 + npm ci
+    J->>N: setup-node@v6 + npm ci
     Note over J: if event_name=schedule, map cron to agent
     J->>C: source scripts/agents/config.sh
     C->>G: create_agent_branch (checkout development, pull, checkout -b)
@@ -390,7 +390,7 @@ flowchart LR
     subgraph Pre["Before the agent starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: bot identity so writes trigger downstream"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: fetch full history (depth 0) for git operations"]:::pre
-        c3["actions/setup-node@v4\nauth: none\nwhy: install Node 20, prime npm cache"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 20, prime npm cache"]:::pre
     end
 
     subgraph During["While the agent runs"]

--- a/.github/docs/BOT_RESPOND_DEEP_DIVE.md
+++ b/.github/docs/BOT_RESPOND_DEEP_DIVE.md
@@ -154,7 +154,7 @@ flowchart TB
         s1["Generate bot token\ncreate-github-app-token@v1"]:::step
         s2["Configure git\nuser.name = llm-exe-bot[bot]\nuser.email = APP_ID+...@users.noreply.github.com"]:::step
         s3["Checkout fetch-depth: 0\nwith bot token"]:::step
-        s4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
+        s4["actions/setup-node@v6\nnode-version: 24, cache: npm"]:::step
         s5["npm ci"]:::step
         s6["Respond step\nclaude-code-action@v1\nmax-turns 90, model configurable"]:::step
         s1 --> s2 --> s3 --> s4 --> s5 --> s6
@@ -363,7 +363,7 @@ flowchart LR
     subgraph Pre["Before the bot starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: mint bot identity"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: full history, fetch-depth 0"]:::pre
-        c3["actions/setup-node@v6\nauth: none\nwhy: Node 20, npm cache"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: Node 24, npm cache"]:::pre
         c4["npm ci\nauth: none\nwhy: install deps so npm test runs"]:::pre
     end
 

--- a/.github/docs/BOT_RESPOND_DEEP_DIVE.md
+++ b/.github/docs/BOT_RESPOND_DEEP_DIVE.md
@@ -154,7 +154,7 @@ flowchart TB
         s1["Generate bot token\ncreate-github-app-token@v1"]:::step
         s2["Configure git\nuser.name = llm-exe-bot[bot]\nuser.email = APP_ID+...@users.noreply.github.com"]:::step
         s3["Checkout fetch-depth: 0\nwith bot token"]:::step
-        s4["actions/setup-node@v4\nnode-version: 20, cache: npm"]:::step
+        s4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
         s5["npm ci"]:::step
         s6["Respond step\nclaude-code-action@v1\nmax-turns 90, model configurable"]:::step
         s1 --> s2 --> s3 --> s4 --> s5 --> s6
@@ -192,7 +192,7 @@ sequenceDiagram
     T-->>J: bot token (short-lived)
     J->>G: git config llm-exe-bot[bot]
     J->>G: checkout fetch-depth 0 with bot token
-    J->>N: setup-node@v4 + npm ci
+    J->>N: setup-node@v6 + npm ci
     J->>CCA: run inline prompt + claude_args
     CCA->>API: read CLAUDE.md (Read tool)
     CCA->>API: gh pr view / gh pr diff (Bash tool)
@@ -363,7 +363,7 @@ flowchart LR
     subgraph Pre["Before the bot starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: mint bot identity"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: full history, fetch-depth 0"]:::pre
-        c3["actions/setup-node@v4\nauth: none\nwhy: Node 20, npm cache"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: Node 20, npm cache"]:::pre
         c4["npm ci\nauth: none\nwhy: install deps so npm test runs"]:::pre
     end
 

--- a/.github/docs/CODER_RUN_DEEP_DIVE.md
+++ b/.github/docs/CODER_RUN_DEEP_DIVE.md
@@ -191,7 +191,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth 0"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["setup-node@v6\nnode 20, cache npm"]:::step
+        r4["setup-node@v6\nnode 24, cache npm"]:::step
         r5["npm ci"]:::step
         r6["Build prompt step\n(branch, log, prompt assembly,\nAssigned Issue block)"]:::step
         r7["Run coder step\nanthropics/claude-code-action@v1"]:::step
@@ -360,7 +360,7 @@ flowchart LR
         c3["gh issue list --json number,labels (find-issues)\nauth: bot token\nwhy: candidate set"]:::pre
         c4["gh pr list --author app/llm-exe-bot (find-issues)\nauth: bot token\nwhy: claimed detection"]:::pre
         c5["actions/checkout@v4 fetch-depth 0\nauth: bot token\nwhy: full history for branch ops"]:::pre
-        c6["actions/setup-node@v6 + npm ci\nauth: none\nwhy: Node 20, prime npm cache"]:::pre
+        c6["actions/setup-node@v6 + npm ci\nauth: none\nwhy: Node 24, prime npm cache"]:::pre
     end
 
     subgraph During["While the agent runs (per leg)"]

--- a/.github/docs/CODER_RUN_DEEP_DIVE.md
+++ b/.github/docs/CODER_RUN_DEEP_DIVE.md
@@ -191,7 +191,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth 0"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["setup-node@v4\nnode 20, cache npm"]:::step
+        r4["setup-node@v6\nnode 20, cache npm"]:::step
         r5["npm ci"]:::step
         r6["Build prompt step\n(branch, log, prompt assembly,\nAssigned Issue block)"]:::step
         r7["Run coder step\nanthropics/claude-code-action@v1"]:::step
@@ -255,7 +255,7 @@ sequenceDiagram
         TK-->>J: bot token
         J->>G: checkout fetch-depth 0 with bot token
         J->>G: git config llm-exe-bot[bot]
-        J->>N: setup-node@v4 + npm ci
+        J->>N: setup-node@v6 + npm ci
         J->>C: source scripts/agents/config.sh
         C->>G: create_agent_branch coder issue-N\n(checkout development, pull, checkout -b)
         G-->>C: agent/coder/(date)-issue-N
@@ -360,7 +360,7 @@ flowchart LR
         c3["gh issue list --json number,labels (find-issues)\nauth: bot token\nwhy: candidate set"]:::pre
         c4["gh pr list --author app/llm-exe-bot (find-issues)\nauth: bot token\nwhy: claimed detection"]:::pre
         c5["actions/checkout@v4 fetch-depth 0\nauth: bot token\nwhy: full history for branch ops"]:::pre
-        c6["actions/setup-node@v4 + npm ci\nauth: none\nwhy: Node 20, prime npm cache"]:::pre
+        c6["actions/setup-node@v6 + npm ci\nauth: none\nwhy: Node 20, prime npm cache"]:::pre
     end
 
     subgraph During["While the agent runs (per leg)"]

--- a/.github/docs/DEPLOY_DOCS_DEEP_DIVE.md
+++ b/.github/docs/DEPLOY_DOCS_DEEP_DIVE.md
@@ -148,7 +148,7 @@ flowchart TB
         direction TB
         s1["checkout@v4 (default GITHUB_TOKEN)"]:::step
         s2["./.github/actions/setup-node (Node 24.x)"]:::step
-        s3["./.github/actions/cache (npm + node_modules)"]:::step
+        s3["./.github/actions/cache (node_modules)"]:::step
         s4["npm install"]:::step
         s5["read package.json version"]:::step
         s6["compute PACKAGE_ID = version-timestamp"]:::step
@@ -327,7 +327,7 @@ flowchart LR
     subgraph Pre["Before AWS"]
         c1["actions/checkout@v4\nauth: default GITHUB_TOKEN\nwhy: clone repo at the dispatched ref"]:::pre
         c2["./.github/actions/setup-node\nauth: none\nwhy: install Node 24.x + npm registry"]:::pre
-        c3["./.github/actions/cache\nauth: none\nwhy: warm ~/.npm and node_modules"]:::pre
+        c3["./.github/actions/cache\nauth: none\nwhy: warm node_modules"]:::pre
         c4["npm registry\nauth: anonymous\nwhy: npm install"]:::build
     end
 
@@ -554,7 +554,7 @@ flowchart LR
     K5["Branch guard (dispatch)"]:::k --- V5["GITHUB_REF in development|main"]:::v
     K6["Jobs"]:::k --- V6["check-deploy-branch, deploy-docs (needs guard)"]:::v
     K7["Node version"]:::k --- V7["24.x (./.github/actions/setup-node)"]:::v
-    K8["Cache"]:::k --- V8["~/.npm and node_modules (./.github/actions/cache)"]:::v
+    K8["Cache"]:::k --- V8["node_modules (./.github/actions/cache); ~/.npm via setup-node@v6 cache: npm"]:::v
     K9["Build commands"]:::k --- V9["npm run docs:update-providers + docs:build"]:::v
     K10["Build output"]:::k --- V10["docs/.vitepress/dist/"]:::v
     K11["PACKAGE_ID"]:::k --- V11["(package.json version)-(unix timestamp)"]:::v

--- a/.github/docs/DOCS_SYNC_DEEP_DIVE.md
+++ b/.github/docs/DOCS_SYNC_DEEP_DIVE.md
@@ -201,7 +201,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth: 0\nwith bot token"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["actions/setup-node@v4\nnode-version: 20, cache: npm"]:::step
+        r4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
         r5["npm ci"]:::step
         r6["Detect changed files\n(writes /tmp/changed-files.txt)"]:::step
         r7["Skip if nothing relevant changed"]:::step
@@ -436,7 +436,7 @@ flowchart LR
     subgraph Pre["Before the agent starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: bot identity so PR triggers reviewer"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: full history for git diff"]:::pre
-        c3["actions/setup-node@v4\nauth: none\nwhy: install Node 20, cache npm"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 20, cache npm"]:::pre
     end
 
     subgraph During["While the agent runs"]

--- a/.github/docs/DOCS_SYNC_DEEP_DIVE.md
+++ b/.github/docs/DOCS_SYNC_DEEP_DIVE.md
@@ -201,7 +201,7 @@ flowchart TB
         r1["Generate bot token"]:::step
         r2["Checkout fetch-depth: 0\nwith bot token"]:::step
         r3["Configure git\nuser.name = llm-exe-bot[bot]"]:::step
-        r4["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::step
+        r4["actions/setup-node@v6\nnode-version: 24, cache: npm"]:::step
         r5["npm ci"]:::step
         r6["Detect changed files\n(writes /tmp/changed-files.txt)"]:::step
         r7["Skip if nothing relevant changed"]:::step
@@ -436,7 +436,7 @@ flowchart LR
     subgraph Pre["Before the agent starts"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: bot identity so PR triggers reviewer"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nwhy: full history for git diff"]:::pre
-        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 20, cache npm"]:::pre
+        c3["actions/setup-node@v6\nauth: none\nwhy: install Node 24, cache npm"]:::pre
     end
 
     subgraph During["While the agent runs"]

--- a/.github/docs/PACK_PACKAGE_DEEP_DIVE.md
+++ b/.github/docs/PACK_PACKAGE_DEEP_DIVE.md
@@ -49,7 +49,7 @@ flowchart LR
 
     subgraph X["External"]
         x1["actions/checkout@v4"]:::ext
-        x2["actions/setup-node@v4\nNode 24.x"]:::ext
+        x2["actions/setup-node@v6\nNode 24.x"]:::ext
         x3["actions/cache@v4\n~/.npm + node_modules"]:::ext
         x4["actions/upload-artifact@v4"]:::ext
         x5["registry.npmjs.org\n(install only)"]:::ext
@@ -174,7 +174,7 @@ sequenceDiagram
     Note over J: bypass gate evaluated on job.if
     J->>CO: checkout default ref
     CO-->>FS: working tree at merge commit
-    J->>SN: setup-node@v4 (Node 24.x, npm registry)
+    J->>SN: setup-node@v6 (Node 24.x, npm registry)
     SN-->>J: node and npm on PATH
     J->>CA: restore ~/.npm and node_modules by hash(package.json)
     CA-->>FS: cache hit or miss (warm start either way)

--- a/.github/docs/PACK_PACKAGE_DEEP_DIVE.md
+++ b/.github/docs/PACK_PACKAGE_DEEP_DIVE.md
@@ -50,7 +50,7 @@ flowchart LR
     subgraph X["External"]
         x1["actions/checkout@v4"]:::ext
         x2["actions/setup-node@v6\nNode 24.x"]:::ext
-        x3["actions/cache@v4\n~/.npm + node_modules"]:::ext
+        x3["actions/cache@v4\nnode_modules"]:::ext
         x4["actions/upload-artifact@v4"]:::ext
         x5["registry.npmjs.org\n(install only)"]:::ext
     end
@@ -136,7 +136,7 @@ flowchart TB
         direction TB
         s1["actions/checkout@v4"]:::step
         s2["./.github/actions/setup-node\nNode 24.x"]:::step
-        s3["./.github/actions/cache\n~/.npm + node_modules"]:::step
+        s3["./.github/actions/cache\nnode_modules"]:::step
         s4["npm install"]:::step
         s5["npm run build:package"]:::step
         s6["npm pack"]:::step
@@ -176,7 +176,7 @@ sequenceDiagram
     CO-->>FS: working tree at merge commit
     J->>SN: setup-node@v6 (Node 24.x, npm registry)
     SN-->>J: node and npm on PATH
-    J->>CA: restore ~/.npm and node_modules by hash(package.json)
+    J->>CA: restore node_modules by hash(package.json)
     CA-->>FS: cache hit or miss (warm start either way)
     J->>NPM: npm install
     NPM-->>FS: node_modules populated
@@ -336,7 +336,7 @@ flowchart LR
     K4["Permissions"]:::k --- V4["id-token: write, contents: read"]:::v
     K5["Runner"]:::k --- V5["ubuntu-latest"]:::v
     K6["Node"]:::k --- V6["24.x via setup-node composite"]:::v
-    K7["Cache"]:::k --- V7["~/.npm + node_modules keyed by package.json hash"]:::v
+    K7["Cache"]:::k --- V7["node_modules keyed by package.json hash; ~/.npm via setup-node@v6 cache: npm"]:::v
     K8["Build script"]:::k --- V8["npm run build:package (tsup with externals)"]:::v
     K9["Pack command"]:::k --- V9["npm pack"]:::v
     K10["Artifact name"]:::k --- V10["package"]:::v

--- a/.github/docs/PERSONAS_RUN_DEEP_DIVE.md
+++ b/.github/docs/PERSONAS_RUN_DEEP_DIVE.md
@@ -488,7 +488,7 @@ flowchart LR
     subgraph Pre["Each job startup (gate, pick, every matrix slot, curator)"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: short-lived bot token per job"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nfetch-depth: 0 (full history for branch ops)"]:::pre
-        c3["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::pre
+        c3["actions/setup-node@v6\nnode-version: 24, cache: npm"]:::pre
     end
 
     subgraph During["While the LLM runs (persona OR curator)"]

--- a/.github/docs/PERSONAS_RUN_DEEP_DIVE.md
+++ b/.github/docs/PERSONAS_RUN_DEEP_DIVE.md
@@ -253,7 +253,7 @@ flowchart TB
         c1["Generate bot token"]:::step
         c2["Checkout fetch-depth: 0"]:::step
         c3["Configure git"]:::step
-        c4["setup-node@v4 + npm ci"]:::step
+        c4["setup-node@v6 + npm ci"]:::step
         c5["Build curator prompt"]:::step
         c6["Run curator\nclaude-code-action@v1"]:::step
         c7["Clock out (if: always())"]:::step
@@ -488,7 +488,7 @@ flowchart LR
     subgraph Pre["Each job startup (gate, pick, every matrix slot, curator)"]
         c1["actions/create-github-app-token@v1\nauth: APP_ID + APP_PRIVATE_KEY\nwhy: short-lived bot token per job"]:::pre
         c2["actions/checkout@v4\nauth: bot token\nfetch-depth: 0 (full history for branch ops)"]:::pre
-        c3["actions/setup-node@v4\nnode-version: 20, cache: npm"]:::pre
+        c3["actions/setup-node@v6\nnode-version: 20, cache: npm"]:::pre
     end
 
     subgraph During["While the LLM runs (persona OR curator)"]

--- a/.github/docs/PUBLISH_RELEASE_DEEP_DIVE.md
+++ b/.github/docs/PUBLISH_RELEASE_DEEP_DIVE.md
@@ -157,7 +157,7 @@ flowchart TB
     subgraph J2["Job: run-examples-tests (ubuntu-latest, Examples Test env)"]
         direction TB
         e1["actions/checkout@v4"]:::step
-        e2["setup-node@v4 Node 22.x"]:::step
+        e2["setup-node@v6 Node 22.x"]:::step
         e3["./.github/actions/cache"]:::step
         e4["npm install"]:::step
         e5["npm run build:package && npm pack"]:::step
@@ -342,13 +342,13 @@ flowchart LR
 
     subgraph ExTest["Examples tests job"]
         e1["actions/checkout@v4\nauth: GITHUB_TOKEN (default)\nwhy: source for build + pack"]:::test
-        e2["actions/setup-node@v4\nauth: none\nwhy: Node 22.x"]:::test
+        e2["actions/setup-node@v6\nauth: none\nwhy: Node 22.x"]:::test
         e3["Provider APIs (OpenAI, Anthropic,\nGemini, xAI, DeepSeek)\nauth: per-provider API keys\nwhy: real integration tests"]:::test
     end
 
     subgraph Pre["Publish job setup"]
         c1["actions/checkout@v4\nauth: GITHUB_TOKEN (default)\nwhy: source for build"]:::pre
-        c2["actions/setup-node@v4 (composite)\nauth: none\nwhy: Node 24.x + npm registry-url"]:::pre
+        c2["actions/setup-node@v6 (composite)\nauth: none\nwhy: Node 24.x + npm registry-url"]:::pre
         c3["actions/cache@v4 (composite)\nauth: none\nwhy: speed up npm install"]:::pre
     end
 

--- a/.github/docs/PUBLISH_RELEASE_DEEP_DIVE.md
+++ b/.github/docs/PUBLISH_RELEASE_DEEP_DIVE.md
@@ -175,7 +175,7 @@ flowchart TB
         s1["actions/checkout@v4"]:::step
         s2["Validate Publisher\n(actor allowlist)"]:::gate
         s3["./.github/actions/setup-node\n(Node 24.x + npm registry-url)"]:::step
-        s4["./.github/actions/cache\n(~/.npm + node_modules)"]:::step
+        s4["./.github/actions/cache\n(node_modules)"]:::step
         s5["npm install"]:::step
         s6["npm run build:package\n(tsup CJS+ESM+DTS)"]:::step
         s7["Publish (route by version)"]:::step
@@ -270,7 +270,7 @@ sequenceDiagram
     J->>J: Validate Publisher (actor in allowlist)
     J->>N: setup-node composite (Node 24.x, registry-url npmjs.org)
     Note over N: registry-url makes npm write an .npmrc with NODE_AUTH_TOKEN
-    J->>N: cache restore (~/.npm + node_modules)
+    J->>N: cache restore (node_modules)
     J->>N: npm install
     J->>B: npm run build:package (tsup CJS + ESM + DTS, externals listed)
     B-->>J: dist/ ready
@@ -580,7 +580,7 @@ flowchart LR
     K6b["Examples tests"]:::k --- V6b["Node 22.x, Examples Test env,\nreal provider keys, npm run test-examples"]:::v
     K7["Node version (publish)"]:::k --- V7["24.x via ./.github/actions/setup-node"]:::v
     K8["Registry"]:::k --- V8["registry.npmjs.org"]:::v
-    K9["Cache"]:::k --- V9["~/.npm and node_modules (composite)"]:::v
+    K9["Cache"]:::k --- V9["node_modules (composite); ~/.npm via setup-node@v6 cache: npm"]:::v
     K10["Build"]:::k --- V10["npm run build:package (tsup CJS+ESM+DTS)"]:::v
     K11["Publish (stable)"]:::k --- V11["npm run publish-main = npm publish --provenance (latest dist-tag)"]:::v
     K12["Publish (pre-release)"]:::k --- V12["npm publish --provenance --tag $CHANNEL (beta, rc, alpha, ...)"]:::v

--- a/.github/docs/TESTS_DEEP_DIVE.md
+++ b/.github/docs/TESTS_DEEP_DIVE.md
@@ -43,7 +43,7 @@ flowchart LR
 
     subgraph C["Caches"]
         c1["setup-node built-in\n(npm cache)"]:::out
-        c2["./.github/actions/cache\n~/.npm + node_modules\nkeyed on matrix.node-version"]:::out
+        c2["./.github/actions/cache\nnode_modules\nkeyed on matrix.node-version"]:::out
     end
 
     subgraph X["External"]
@@ -180,7 +180,7 @@ sequenceDiagram
     R->>SN: setup-node@v6, node-version, cache: npm
     SN-->>R: node + npm installed, ~/.npm primed
     R->>CA: composite cache action
-    CA-->>R: ~/.npm and node_modules restored if hit
+    CA-->>R: node_modules restored if hit
     R->>NPM: npm install (not ci)
     NPM-->>R: node_modules ready
     R->>J: npm run test (Jest with coverage, forceExit)
@@ -219,14 +219,9 @@ flowchart LR
     end
 
     subgraph L2["Layer 2: ./.github/actions/cache (composite)"]
-        l2a["actions/cache@v4 (entry A)"]:::comp
-        l2b["actions/cache@v4 (entry B)"]:::comp
-        l2ap["~/.npm"]:::path
+        l2b["actions/cache@v4"]:::comp
         l2bp["node_modules"]:::path
-        l2ak["os-node-{matrix.node-version}-hash(package.json)"]:::key
         l2bk["os-nodeModules-{matrix.node-version}-hash(package.json)"]:::key
-        l2a --> l2ap
-        l2a --> l2ak
         l2b --> l2bp
         l2b --> l2bk
     end
@@ -237,7 +232,7 @@ flowchart LR
 
 Two things to know:
 
-1. The composite action keys on `hashFiles('**/package.json')`, not `package-lock.json`. setup-node's built-in cache keys on `package-lock.json`. They are not redundant, they target different miss patterns.
+1. The composite action keys on `hashFiles('**/package.json')`, not `package-lock.json`. setup-node's built-in cache (Layer 1) keys on `package-lock.json`. The two layers target different miss patterns and cover different paths — there is no overlap.
 2. `npm install` (not `npm ci`) means the workflow will reconcile the lockfile if it drifts from `package.json`. This is intentional given the multi-version matrix but trades strictness for resilience.
 
 Source: [.github/actions/cache/action.yml](../actions/cache/action.yml).
@@ -373,7 +368,7 @@ flowchart LR
     K8["Install"]:::k --- V8["npm install (not ci)"]:::v
     K9["Test"]:::k --- V9["npm run test (Jest, coverage, forceExit)"]:::v
     K10["Cache layer 1"]:::k --- V10["setup-node built-in (~/.npm by lockfile hash)"]:::v
-    K11["Cache layer 2"]:::k --- V11["composite (~/.npm + node_modules by package.json hash)"]:::v
+    K11["Cache layer 2"]:::k --- V11["composite (node_modules by package.json hash)"]:::v
     K12["Coverage upload"]:::k --- V12["coverallsapp/github-action@v1, Node 24.x only"]:::v
     K13["Status checks"]:::k --- V13["one per matrix leg, required by branch protection"]:::v
 ```

--- a/.github/docs/TESTS_DEEP_DIVE.md
+++ b/.github/docs/TESTS_DEEP_DIVE.md
@@ -168,7 +168,7 @@ sequenceDiagram
     participant E as Event
     participant R as Runner (ubuntu-latest)
     participant CO as actions/checkout@v4
-    participant SN as actions/setup-node@v4
+    participant SN as actions/setup-node@v6
     participant CA as ./.github/actions/cache
     participant NPM as npm
     participant J as Jest
@@ -177,7 +177,7 @@ sequenceDiagram
     E->>R: matrix leg starts (node 18/20/22/24)
     R->>CO: actions/checkout@v4
     CO-->>R: working tree at PR HEAD
-    R->>SN: setup-node@v4, node-version, cache: npm
+    R->>SN: setup-node@v6, node-version, cache: npm
     SN-->>R: node + npm installed, ~/.npm primed
     R->>CA: composite cache action
     CA-->>R: ~/.npm and node_modules restored if hit
@@ -210,8 +210,8 @@ flowchart LR
     classDef path fill:#374151,color:#fff,stroke:#000
     classDef key fill:#581c87,color:#fff,stroke:#000
 
-    subgraph L1["Layer 1: setup-node@v4 (cache: npm)"]
-        l1act["actions/setup-node@v4"]:::builtin
+    subgraph L1["Layer 1: setup-node@v6 (cache: npm)"]
+        l1act["actions/setup-node@v6"]:::builtin
         l1path["~/.npm"]:::path
         l1key["key: hash of package-lock.json"]:::key
         l1act --> l1path
@@ -256,7 +256,7 @@ flowchart LR
 
     subgraph Setup
         s1["actions/checkout@v4\nauth: GITHUB_TOKEN\nwhy: get PR HEAD"]:::setup
-        s2["actions/setup-node@v4\nauth: none\nwhy: install Node, prime npm cache"]:::setup
+        s2["actions/setup-node@v6\nauth: none\nwhy: install Node, prime npm cache"]:::setup
         s3["actions/cache@v4 (x2)\nauth: GITHUB_TOKEN\nwhy: persist deps across runs"]:::setup
     end
 

--- a/.github/docs/TEST_PACKAGE_DEEP_DIVE.md
+++ b/.github/docs/TEST_PACKAGE_DEEP_DIVE.md
@@ -157,7 +157,7 @@ flowchart TB
     subgraph J["Job: test-package (ubuntu-latest, env: Examples Test)"]
         direction TB
         s1["Checkout repository\nactions/checkout@v4"]:::step
-        s2["Use Latest Node.js 22.x\nactions/setup-node@v4 (cache: npm)"]:::step
+        s2["Use Latest Node.js 22.x\nactions/setup-node@v6 (cache: npm)"]:::step
         s3["Cache npm dependencies\n./.github/actions/cache"]:::step
         s4["Install dependencies\nnpm install"]:::step
         s5["Build package and pack package\nnpm run build:package &amp;&amp; npm pack"]:::step
@@ -200,7 +200,7 @@ sequenceDiagram
     U->>E: workflow_dispatch (actor=gregreindel)
     E->>J: gate check (actor + environment)
     J->>FS: checkout repo at ref
-    J->>N: setup-node@v4 (22.x, cache: npm)
+    J->>N: setup-node@v6 (22.x, cache: npm)
     J->>N: ./.github/actions/cache (warm ~/.npm + node_modules)
     J->>N: npm install (dev deps for build)
     J->>B: npm run build:package (tsup, external deps)
@@ -352,7 +352,7 @@ flowchart LR
 
     subgraph Pre["Before tests"]
         c1["actions/checkout@v4\nauth: GITHUB_TOKEN\nwhy: get source"]:::pre
-        c2["actions/setup-node@v4\nauth: none\nwhy: Node 22.x install"]:::pre
+        c2["actions/setup-node@v6\nauth: none\nwhy: Node 22.x install"]:::pre
         c3["registry.npmjs.org\nauth: none\nwhy: npm install (dev deps + examples deps)"]:::reg
     end
 

--- a/.github/docs/TEST_PACKAGE_DEEP_DIVE.md
+++ b/.github/docs/TEST_PACKAGE_DEEP_DIVE.md
@@ -201,7 +201,7 @@ sequenceDiagram
     E->>J: gate check (actor + environment)
     J->>FS: checkout repo at ref
     J->>N: setup-node@v6 (22.x, cache: npm)
-    J->>N: ./.github/actions/cache (warm ~/.npm + node_modules)
+    J->>N: ./.github/actions/cache (warm node_modules)
     J->>N: npm install (dev deps for build)
     J->>B: npm run build:package (tsup, external deps)
     B-->>FS: dist/index.js, dist/index.mjs, dist/index.d.ts

--- a/.github/docs/WORKFLOW_ARCHITECTURE.md
+++ b/.github/docs/WORKFLOW_ARCHITECTURE.md
@@ -329,8 +329,8 @@ The minimal tree, annotated with why each path exists. A replica must reproduce 
 .
 ├── .github/
 │   ├── actions/
-│   │   ├── cache/action.yml              composite action: caches ~/.npm and node_modules keyed on matrix.node-version plus hashFiles('**/package.json')
-│   │   └── setup-node/action.yml         composite action: actions/setup-node@v6 pinned to 24.x with registry-url https://registry.npmjs.org
+│   │   ├── cache/action.yml              composite action: caches node_modules keyed on matrix.node-version plus hashFiles('**/package.json'); ~/.npm is handled by actions/setup-node@v6 with cache: npm
+│   │   └── setup-node/action.yml         composite action: actions/setup-node@v6 pinned to 24.x with cache: npm and registry-url https://registry.npmjs.org
 │   ├── workflows/
 │   │   ├── agent-run.yml                 task agents (docs, tester, coder, scout) on cron plus dispatch
 │   │   ├── coder-run.yml                 fans the coder out across up to 5 unclaimed issues in a matrix
@@ -1254,23 +1254,19 @@ runs:
     - uses: actions/setup-node@v6
       with:
         node-version: 24.x
+        cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 ```
 
 `.github/actions/cache/action.yml`:
 ```yaml
-name: 'Cache npm dependencies and node modules'
-description: 'Cache npm dependencies and node modules'
+name: 'Cache node modules'
+description: 'Cache node_modules directory. npm global cache (~/.npm) is handled by actions/setup-node cache: npm.'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ matrix.node-version }}-
-    - uses: actions/cache@v4
+    - name: Cache node modules
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-nodeModules-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
@@ -1278,7 +1274,7 @@ runs:
           ${{ runner.os }}-nodeModules-${{ matrix.node-version }}-
 ```
 
-Note: `cache/action.yml` references `matrix.node-version`. It only makes sense when used inside a matrixed job (like `tests.yml`). Calling it from a non-matrix job results in an empty matrix variable and a cache key the runner accepts but that will not hit on subsequent runs.
+Note: `cache/action.yml` references `matrix.node-version`. It only makes sense when used inside a matrixed job (like `tests.yml`). Calling it from a non-matrix job results in an empty matrix variable and a cache key the runner accepts but that will not hit on subsequent runs. The `~/.npm` cache entry previously in this action was removed in v6 — `actions/setup-node@v6` with `cache: 'npm'` handles that, keying on `package-lock.json`.
 
 ## Appendix C: Why these choices
 

--- a/.github/docs/WORKFLOW_ARCHITECTURE.md
+++ b/.github/docs/WORKFLOW_ARCHITECTURE.md
@@ -426,7 +426,7 @@ sequenceDiagram
     App-->>Runner: short-lived token for llm-exe-bot[bot]
     Runner->>Git: checkout fetch-depth: 0 using bot token
     Runner->>Runner: git config user.name llm-exe-bot[bot]
-    Runner->>Runner: setup-node@v6 node-version 20 cache npm
+    Runner->>Runner: setup-node@v6 node-version 24 cache npm
     Runner->>Runner: npm ci
     Runner->>Cfg: source scripts/agents/config.sh
     Cfg->>Cfg: create_agent_branch "<role>" [suffix]
@@ -614,7 +614,7 @@ flowchart LR
     C --> D[mint bot token]
     D --> E[checkout fetch-depth 0]
     E --> F[git config bot identity]
-    F --> G[setup-node 20 cache npm]
+    F --> G[setup-node 24 cache npm]
     G --> H[npm ci]
     H --> I{event is schedule?}
     I -->|yes| J[Pick agent from cron string]

--- a/.github/docs/WORKFLOW_ARCHITECTURE.md
+++ b/.github/docs/WORKFLOW_ARCHITECTURE.md
@@ -330,7 +330,7 @@ The minimal tree, annotated with why each path exists. A replica must reproduce 
 ├── .github/
 │   ├── actions/
 │   │   ├── cache/action.yml              composite action: caches ~/.npm and node_modules keyed on matrix.node-version plus hashFiles('**/package.json')
-│   │   └── setup-node/action.yml         composite action: actions/setup-node@v4 pinned to 24.x with registry-url https://registry.npmjs.org
+│   │   └── setup-node/action.yml         composite action: actions/setup-node@v6 pinned to 24.x with registry-url https://registry.npmjs.org
 │   ├── workflows/
 │   │   ├── agent-run.yml                 task agents (docs, tester, coder, scout) on cron plus dispatch
 │   │   ├── coder-run.yml                 fans the coder out across up to 5 unclaimed issues in a matrix
@@ -426,7 +426,7 @@ sequenceDiagram
     App-->>Runner: short-lived token for llm-exe-bot[bot]
     Runner->>Git: checkout fetch-depth: 0 using bot token
     Runner->>Runner: git config user.name llm-exe-bot[bot]
-    Runner->>Runner: setup-node@v4 node-version 20 cache npm
+    Runner->>Runner: setup-node@v6 node-version 20 cache npm
     Runner->>Runner: npm ci
     Runner->>Cfg: source scripts/agents/config.sh
     Cfg->>Cfg: create_agent_branch "<role>" [suffix]
@@ -745,7 +745,7 @@ Body must be HTML fragment (no `<html>` / `<body>` tags) and must be the only th
 | Push rationale | Coverage upload is gated to Node 24.x. Without a `push` event on `main`, every Coveralls record is tagged with the source PR head branch (development / feature branches), so the docs-site badge that filters with `?branch=main` renders "unknown". The `push` trigger on `main` (always reached via `auto-merge-main-pr.yml`) produces a Coveralls record tagged for `main`. |
 | Bypass | Job-level `if` skips when `pull_request.base.ref == 'development' && pull_request.head.ref == 'bump-version-branch'`. On `push` and `workflow_dispatch` `pull_request` is null, so the bypass is false and the matrix runs. |
 | Matrix | Node 18, 20, 22, 24 |
-| Steps | `actions/checkout@v4` -> `actions/setup-node@v4` with `cache: npm` -> reusable cache action -> `npm install` -> `npm run test` -> coverage upload on Node 24 only |
+| Steps | `actions/checkout@v4` -> `actions/setup-node@v6` with `cache: npm` -> reusable cache action -> `npm install` -> `npm run test` -> coverage upload on Node 24 only |
 
 Note: this workflow does not use the App token. It only needs reads.
 
@@ -1251,7 +1251,7 @@ description: "Setup Node.js environment"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24.x
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/agent-review-pr.yml
+++ b/.github/workflows/agent-review-pr.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/agent-review-pr.yml
+++ b/.github/workflows/agent-review-pr.yml
@@ -54,7 +54,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -92,7 +92,7 @@ jobs:
           token: ${{ steps.review-bot-token.outputs.token }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -91,7 +91,7 @@ jobs:
           git config user.email "${{ secrets.APP_ID }}+llm-exe-bot[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/bot-respond.yml
+++ b/.github/workflows/bot-respond.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/bot-respond.yml
+++ b/.github/workflows/bot-respond.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/coder-run.yml
+++ b/.github/workflows/coder-run.yml
@@ -119,7 +119,7 @@ jobs:
           git config user.email "${{ secrets.APP_ID }}+llm-exe-bot[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/coder-run.yml
+++ b/.github/workflows/coder-run.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -61,7 +61,7 @@ jobs:
           git config user.email "${{ secrets.APP_ID }}+llm-exe-bot[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/personas-run.yml
+++ b/.github/workflows/personas-run.yml
@@ -99,7 +99,7 @@ jobs:
           git config user.email "${{ secrets.APP_ID }}+llm-exe-bot[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -188,7 +188,7 @@ jobs:
           git config user.email "${{ secrets.APP_ID }}+llm-exe-bot[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/personas-run.yml
+++ b/.github/workflows/personas-run.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Latest Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Latest Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
This pull request updates the Node.js setup and caching strategy across the GitHub Actions workflows and documentation. The main changes are: upgrading all references from `setup-node@v4` to `setup-node@v6`, switching the caching approach to rely on `setup-node`'s built-in npm cache for `~/.npm`, bumping agent/tool workflow runtimes from Node 20 to Node 24 ahead of the runner deprecation, and updating diagrams and documentation to reflect these improvements.

**Node.js setup and versioning:**
* Upgraded all workflow and documentation references from `actions/setup-node@v4` to `actions/setup-node@v6`, ensuring the latest features and improved support for cache management.

**Caching improvements:**
* Modified `.github/actions/cache/action.yml` and related documentation to stop caching the global npm cache (`~/.npm`) directly; now only `node_modules` is cached, while `~/.npm` is handled via `setup-node@v6`'s `cache: npm` option.
* Added `cache: 'npm'` to the composite `.github/actions/setup-node` action so `pack-package.yml`, `deploy-docs.yml`, and the publish job in `publish-release.yml` get the same built-in npm caching as the other workflows.

**Node 20 → 24 runtime bump (agent/tool workflows):**
* GitHub is deprecating Node 20 on Actions runners ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)), with removal beginning June 16, 2026. Agent and tool workflows that used a fixed `node-version: 20` just to run scripts (`npm ci`, `npm test`, agent invocations) have been bumped to `node-version: 24` — the current LTS. Affected workflows: `agent-review-pr.yml` (review job), `agent-run.yml`, `bot-respond.yml`, `coder-run.yml`, `docs-sync.yml`, `personas-run.yml` (both jobs).
* Test matrices are intentionally unchanged — Node 18 and 20 remain in `[18.x, 20.x, 22.x, 24.x]` for compatibility coverage until the runner removes them.
* All deep-dive docs updated to match: `AGENT_RUN_DEEP_DIVE.md`, `BOT_RESPOND_DEEP_DIVE.md`, `CODER_RUN_DEEP_DIVE.md`, `DOCS_SYNC_DEEP_DIVE.md`, `PERSONAS_RUN_DEEP_DIVE.md`, `AGENT_REVIEW_PR_DEEP_DIVE.md`, `WORKFLOW_ARCHITECTURE.md`.

**Workflow configuration:**
* Updated `.github/actions/setup-node/action.yml` to use `actions/setup-node@v6` and enable npm cache via the `cache: 'npm'` option, improving cache efficiency and reliability.

**Documentation and diagrams:**
* Updated all workflow diagrams, flowcharts, and sequence diagrams in the `.github/docs/` directory to reflect the switch to `setup-node@v6`, the new caching strategy, and the Node 24 runtime for agent jobs.