### PR TITLE
fix(anthropic): remove retired Claude Opus 4 / Sonnet 4 shorthands

### DIFF
--- a/src/interfaces/llm.ts
+++ b/src/interfaces/llm.ts
@@ -683,18 +683,9 @@ export type AllUseLlmOptions = AllLlm & {
   "anthropic.claude-opus-4-6": {
     input: Omit<AnthropicRequest, "model">;
   };
-  "anthropic.claude-sonnet-4-0": {
-    input: Omit<AnthropicRequest, "model">;
-  };
-  "anthropic.claude-opus-4-0": {
-    input: Omit<AnthropicRequest, "model">;
-  };
-  "anthropic.claude-sonnet-4": {
-    input: Omit<AnthropicRequest, "model">;
-  };
-  "anthropic.claude-opus-4": {
-    input: Omit<AnthropicRequest, "model">;
-  };
+  // Removed: Claude Opus 4 / Sonnet 4 (claude-opus-4-0, claude-sonnet-4-0) are
+  // retired at Anthropic (HTTP 404). The claude-*-4-0 keys were type-only orphans
+  // with no runtime shorthand and threw "Invalid provider" if used.
   "anthropic.claude-3-7-sonnet": {
     input: Omit<AnthropicRequest, "model">;
   };

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -53,8 +53,6 @@ describe("anthropic config", () => {
   describe("deprecated shorthands still resolve", () => {
     it.each([
       ["anthropic.claude-opus-4-6", "claude-opus-4-6"],
-      ["anthropic.claude-sonnet-4", "claude-sonnet-4-0"],
-      ["anthropic.claude-opus-4", "claude-opus-4-0"],
       ["anthropic.claude-3-7-sonnet", "claude-3-7-sonnet-20250219"],
       ["anthropic.claude-3-5-sonnet", "claude-3-5-sonnet-latest"],
       ["anthropic.claude-3-5-haiku", "claude-3-5-haiku-latest"],
@@ -93,6 +91,15 @@ describe("anthropic config", () => {
     it("no longer exposes anthropic.claude-opus-4-1 (model retired Aug 5, 2026)", () => {
       expect(
         (anthropic as Record<string, unknown>)["anthropic.claude-opus-4-1"]
+      ).toBeUndefined();
+    });
+
+    it.each([
+      "anthropic.claude-opus-4",
+      "anthropic.claude-sonnet-4",
+    ])("no longer exposes %s (model retired at Anthropic — HTTP 404)", (shorthand) => {
+      expect(
+        (anthropic as Record<string, unknown>)[shorthand]
       ).toBeUndefined();
     });
   });
@@ -159,8 +166,6 @@ describe("anthropic config", () => {
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "claude-sonnet-4-5",
-        "claude-sonnet-4-0",
-        "claude-opus-4-0",
       ]) {
         const body = buildBody({ model, temperature: 0.5, topP: 0.9 });
         expect(body.temperature).toBe(0.5);

--- a/src/llm/config/anthropic/index.ts
+++ b/src/llm/config/anthropic/index.ts
@@ -171,16 +171,12 @@ export const anthropic = {
   // NOTE: "anthropic.claude-opus-4-1" (claude-opus-4-1-20250805) was removed —
   // Anthropic retires that model on Aug 5, 2026. Migrate to
   // anthropic.claude-opus-4-5/-6/-7/-8.
-  ...deprecateShorthand("anthropic.claude-sonnet-4", {
-    config: withDefaultModel(anthropicChatV1, "claude-sonnet-4-0"),
-    message:
-      'Shorthand "anthropic.claude-sonnet-4" is deprecated and may be removed in a future release.',
-  }),
-  ...deprecateShorthand("anthropic.claude-opus-4", {
-    config: withDefaultModel(anthropicChatV1, "claude-opus-4-0"),
-    message:
-      'Shorthand "anthropic.claude-opus-4" is deprecated and may be removed in a future release.',
-  }),
+  // NOTE: "anthropic.claude-sonnet-4" (claude-sonnet-4-0) and
+  // "anthropic.claude-opus-4" (claude-opus-4-0) were removed — Anthropic has
+  // retired both models. Both the base aliases and the dated snapshots
+  // (claude-opus-4-20250514 / claude-sonnet-4-20250514) now return HTTP 404,
+  // so these shorthands could only ever error. Migrate to
+  // anthropic.claude-opus-4-5/-6/-7/-8 or anthropic.claude-sonnet-4-5/-4-6/-5.
   ...deprecateShorthand("anthropic.claude-3-7-sonnet", {
     config: withDefaultModel(anthropicChatV1, "claude-3-7-sonnet-20250219"),
     message:


### PR DESCRIPTION
Fixes #679

## Summary

Removes two Anthropic shorthands whose underlying models Anthropic has **retired**:

- `anthropic.claude-opus-4` → `claude-opus-4-0`
- `anthropic.claude-sonnet-4` → `claude-sonnet-4-0`

Both currently resolve at the config layer but can only ever error, because the model IDs they point at no longer exist at the provider.

## Why now (evidence)

Verified live against the Anthropic Messages API with a valid key. Both the base aliases **and** the dated snapshots return **HTTP 404 (model not found)**, while a still-live control works on the same key:

```
claude-opus-4-0              -> 404  model: claude-opus-4-0
claude-opus-4-20250514       -> 404  model: claude-opus-4-20250514
claude-sonnet-4-0            -> 404  model: claude-sonnet-4-0
claude-sonnet-4-20250514     -> 404  model: claude-sonnet-4-20250514
(control) claude-opus-4-1-20250805 -> 200 OK
```

Since the models are gone, any `useLlm("anthropic.claude-opus-4")` / `...sonnet-4` call already fails with a 404 today — the shorthands are non-functional, not merely deprecated.

## Policy alignment

Our shorthand policy is: **keep deprecated-but-callable models** (optionally warning), and **only remove once the provider has actually shut a model down**. That condition is now met for Opus 4 and Sonnet 4 — the provider returns 404 — so this is the point at which removal is correct rather than premature. (Contrast: `claude-opus-4-1-20250805` is still callable, `200`, so its model is not shut down yet.)

## What changed

- `src/llm/config/anthropic/index.ts` — removed the two `deprecateShorthand(...)` blocks; left a NOTE documenting the retirement and migration path.
- `src/interfaces/llm.ts` — removed the union entries `anthropic.claude-opus-4` and `anthropic.claude-sonnet-4`, **plus** the type-only orphans `anthropic.claude-opus-4-0` and `anthropic.claude-sonnet-4-0`. Those `-4-0` keys had no runtime config behind them (they threw `Invalid provider` if used) and referenced the same retired models — dangling entries, removed as part of the same cleanup.
- `src/llm/config/anthropic/anthropic.test.ts` — dropped the two resolve-cases and the two retired model strings from the sampling-guard loop; extended the `removed shorthands` block to assert `claude-opus-4` / `claude-sonnet-4` are no longer exposed.

## Migration

Move to a current model:

- Opus: `anthropic.claude-opus-4-5` / `-4-6` / `-4-7` / `-4-8`
- Sonnet: `anthropic.claude-sonnet-4-5` / `-4-6` / `-5`

## Breaking change / versioning

This drops keys from the `useLlm` union type, so TypeScript consumers referencing `anthropic.claude-opus-4` / `anthropic.claude-sonnet-4` (or the `-4-0` orphans) will stop compiling. **However, those calls already fail at runtime** (404, or `Invalid provider` for the orphans), so no working integration is affected — this only surfaces an already-broken reference at compile time instead of at runtime.

Labeled `breaking`. Recommend targeting the next major (`v4.0.0`) per the versioning policy; no `v4.0.0` milestone exists yet, so leaving the milestone to the maintainer.

## Testing

- `npm run typecheck` — clean.
- `npm test` — 191 suites / 2569 tests pass.
- Runtime check on the built package: `anthropic.claude-opus-4` / `-sonnet-4` now throw; migration targets (`-opus-4-5/-4-8`, `-sonnet-4-5`) still resolve.