### PR TITLE
fix(deps): bump handlebars 4.7.8 → 4.7.9 (resolves critical advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "llm-exe",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-exe",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/credential-providers": "3.1073.0",
         "@smithy/signature-v4": "5.1.0",
         "exponential-backoff": "3.1.2",
-        "handlebars": "4.7.8",
+        "handlebars": "4.7.9",
         "json-schema-to-ts": "3.1.1",
         "jsonschema": "1.5.0",
         "shiki": "^3.8.1",
@@ -6344,9 +6344,10 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@aws-sdk/credential-providers": "3.1073.0",
     "@smithy/signature-v4": "5.1.0",
     "exponential-backoff": "3.1.2",
-    "handlebars": "4.7.8",
+    "handlebars": "4.7.9",
     "json-schema-to-ts": "3.1.1",
     "jsonschema": "1.5.0",
     "shiki": "^3.8.1",

--- a/src/utils/modules/handlebars/index.test.ts
+++ b/src/utils/modules/handlebars/index.test.ts
@@ -25,7 +25,7 @@ describe("useHandlebars", () => {
     expect(hbsInstance.handlebars).toHaveProperty("helpers");
     expect(hbsInstance.handlebars).toHaveProperty("partials");
     expect(hbsInstance.handlebars).toHaveProperty("VERSION");
-    expect(hbsInstance.handlebars.VERSION).toEqual("4.7.8");
+    expect(hbsInstance.handlebars.VERSION).toEqual("4.7.9");
   });
 
 });


### PR DESCRIPTION
## Summary

Bumps `handlebars` **4.7.8 → 4.7.9** to resolve the critical security advisories flagged against `handlebars@4.7.8`. Handlebars is a direct production dependency (llm-exe's prompt-templating engine), so this ships to consumers.

## Advisories resolved

`npm audit` flags `handlebars 4.0.0 - 4.7.8` for 8 advisories, including a critical JavaScript-injection class:

| Advisory | Issue |
|---|---|
| GHSA-3mfm-83xf-c92r | JS injection via AST type confusion (`@partial-block`) |
| GHSA-2w6w-674q-4c4q | JS injection via AST type confusion |
| GHSA-2qvq-rjwj-gvw9 | Prototype pollution → XSS via partial injection |
| GHSA-7rx3-28cr-v5wh | Prototype method access gap (`__lookupSetter__`) |
| GHSA-442j-39wm-28r2 | Property access validation bypass (`container.lookup`) |
| GHSA-xhpv-hc6g-r9c6 | JS injection via object as dynamic partial |
| GHSA-9cx6-37pm-9jff | DoS via malformed decorator syntax |
| GHSA-xjpj-3mr7-gcpf | JS injection in CLI precompiler |

`4.7.9` is the patched release — the advisory range ends at `4.7.8`.

## Why this is safe (not just a version pin)

`4.7.8 → 4.7.9` is a backward-compatible patch, but several of these fixes deliberately **tighten property/prototype access** — which is exactly what a templating engine does — so rendering was verified end-to-end rather than assumed:

- **`npm run typecheck`** — clean.
- **`npm test`** — 191 suites / 2604 tests pass (the only test change is the VERSION-pin assertion in `src/utils/modules/handlebars/index.test.ts`, updated `4.7.8` → `4.7.9`).
- **`npm audit` (prod)** — handlebars critical resolved.
- **Live templating render** through the public API (`createChatPrompt().format()` / `.formatAsync()`), covering the exact areas the 4.7.9 fixes touch:
  - variables + nested property access (`{{a.b.c}}`) ✓
  - `{{#if}}` / `{{#each}}` / `{{#unless}}` ✓
  - HTML escaping still escapes (`<script>` → `&lt;script&gt;`) ✓, triple-stache raw still raw ✓
  - custom helpers (`registerHelpers`) and partials (`registerPartials`) ✓
  - `formatAsync` with promise-valued data ✓
  - prototype access (`{{constructor.name}}`) correctly blocked → empty ✓

Every feature renders identically to 4.7.8; the only observable difference is the closed vulnerability.

## Scope

This closes the **handlebars critical** only. Two moderate advisories remain, unrelated to this change and tracked separately:

- `uuid@10.0.0` (direct prod dep; fixed in ≥ 11.1.1)
- `mdast-util-to-hast` (transitive via `shiki`, the docs highlighter)

Also note: the separate `@aws-sdk/credential-providers` bump (#660) closes the `fast-xml-parser` critical.

## Not a breaking change

Patch bump, backward-compatible; public API and rendering behavior unchanged. Targets a patch/minor release.
