### PR TITLE
feat(anthropic): add Claude Opus 5 support

### DIFF
--- a/src/interfaces/llm.ts
+++ b/src/interfaces/llm.ts
@@ -680,6 +680,11 @@ export type AllUseLlmOptions = AllLlm & {
     input: Omit<AnthropicRequest, "model">;
   };
 
+  // Anthropic - Claude Opus 5 models
+  "anthropic.claude-opus-5": {
+    input: Omit<AnthropicRequest, "model">;
+  };
+
   // Anthropic - Claude 4.8 models
   "anthropic.claude-opus-4-8": {
     input: Omit<AnthropicRequest, "model">;

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -114,6 +114,60 @@ describe("anthropic config", () => {
       });
     });
 
+    describe("escalated-effort max_tokens floor", () => {
+      const ESCALATED = ["claude-opus-5", "claude-opus-4-7", "claude-opus-4-8"];
+
+      it.each(ESCALATED)(
+        "%s raises the default 4096 to 65536 when effort escalates to xhigh",
+        (model) => {
+          const output: Record<string, any> = { max_tokens: 4096 };
+          expect(effortTransform("high", { model }, output)).toBe("xhigh");
+          expect(output.max_tokens).toBe(65536);
+        }
+      );
+
+      it.each(ESCALATED)(
+        "%s never lowers a caller's larger max_tokens",
+        (model) => {
+          const output: Record<string, any> = { max_tokens: 128000 };
+          effortTransform("high", { model }, output);
+          expect(output.max_tokens).toBe(128000);
+        }
+      );
+
+      it.each(ESCALATED)(
+        "%s leaves an explicit non-default max_tokens alone, even below the floor",
+        (model) => {
+          // A deliberate cost cap. Unlike the legacy branch (where Anthropic
+          // 400s if max_tokens <= budget_tokens, so overriding is mandatory),
+          // a short max_tokens here is legal — it truncates rather than
+          // erroring — so the caller's choice wins.
+          const output: Record<string, any> = { max_tokens: 2000 };
+          effortTransform("high", { model }, output);
+          expect(output.max_tokens).toBe(2000);
+        }
+      );
+
+      it("does not raise max_tokens when effort does not escalate", () => {
+        for (const model of ["claude-sonnet-5", "claude-sonnet-4-6"]) {
+          const output: Record<string, any> = { max_tokens: 4096 };
+          expect(effortTransform("high", { model }, output)).toBe("high");
+          expect(output.max_tokens).toBe(4096);
+        }
+      });
+
+      it.each(ESCALATED)(
+        "%s does not raise max_tokens below high effort",
+        (model) => {
+          for (const effort of ["minimal", "low", "medium"]) {
+            const output: Record<string, any> = { max_tokens: 4096 };
+            effortTransform(effort, { model }, output);
+            expect(output.max_tokens).toBe(4096);
+          }
+        }
+      );
+    });
+
     describe("legacy thinking (4.5 models)", () => {
       it.each([
         ["claude-sonnet-4-5-20250929", "minimal", 1024],

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -68,7 +68,9 @@ describe("anthropic config", () => {
         ["claude-sonnet-4-6", "low", "low"],
         ["claude-sonnet-4-6", "high", "high"],
         // Newer adaptive models (opus 5, opus 4.8, sonnet 5, fable 5)
-        ["claude-opus-5", "high", "xhigh"],
+        // Opus 5 keeps "high" (Anthropic recommends starting at high on Opus 5),
+        // unlike opus 4.7/4.8 which escalate to xhigh.
+        ["claude-opus-5", "high", "high"],
         ["claude-opus-5", "minimal", "low"],
         ["claude-opus-5", "medium", "medium"],
         ["claude-opus-4-8", "high", "xhigh"],
@@ -88,8 +90,8 @@ describe("anthropic config", () => {
       );
     });
 
-    describe("adaptive thinking maps high to xhigh for Opus coding flagships", () => {
-      it.each(["claude-opus-5", "claude-opus-4-7", "claude-opus-4-8"])(
+    describe("adaptive thinking maps high to xhigh for Opus 4.7/4.8 only", () => {
+      it.each(["claude-opus-4-7", "claude-opus-4-8"])(
         "should map high to xhigh for %s",
         (model) => {
           const output: Record<string, any> = {};
@@ -99,8 +101,12 @@ describe("anthropic config", () => {
         }
       );
 
-      it("should map high to high (not xhigh) for non-opus adaptive models", () => {
-        for (const model of ["claude-sonnet-5", "claude-fable-5"]) {
+      it("keeps high for adaptive models without the xhigh escalation", () => {
+        // Opus 5 sits here on purpose: Anthropic's per-model guidance is to
+        // start with "high" on Opus 5 and warns against carrying the 4.x
+        // escalation over, so "high" must remain reachable. Do not add opus-5
+        // back to the xhigh list above.
+        for (const model of ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"]) {
           const output: Record<string, any> = {};
           expect(effortTransform("high", { model }, output)).toBe("high");
         }
@@ -115,7 +121,9 @@ describe("anthropic config", () => {
     });
 
     describe("escalated-effort max_tokens floor", () => {
-      const ESCALATED = ["claude-opus-5", "claude-opus-4-7", "claude-opus-4-8"];
+      // Only 4.7/4.8 escalate "high" -> "xhigh"; opus-5 stays "high" and never
+      // trips this floor.
+      const ESCALATED = ["claude-opus-4-7", "claude-opus-4-8"];
 
       it.each(ESCALATED)(
         "%s raises the default 4096 to 65536 when effort escalates to xhigh",

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -120,62 +120,6 @@ describe("anthropic config", () => {
       });
     });
 
-    describe("escalated-effort max_tokens floor", () => {
-      // Only 4.7/4.8 escalate "high" -> "xhigh"; opus-5 stays "high" and never
-      // trips this floor.
-      const ESCALATED = ["claude-opus-4-7", "claude-opus-4-8"];
-
-      it.each(ESCALATED)(
-        "%s raises the default 4096 to 65536 when effort escalates to xhigh",
-        (model) => {
-          const output: Record<string, any> = { max_tokens: 4096 };
-          expect(effortTransform("high", { model }, output)).toBe("xhigh");
-          expect(output.max_tokens).toBe(65536);
-        }
-      );
-
-      it.each(ESCALATED)(
-        "%s never lowers a caller's larger max_tokens",
-        (model) => {
-          const output: Record<string, any> = { max_tokens: 128000 };
-          effortTransform("high", { model }, output);
-          expect(output.max_tokens).toBe(128000);
-        }
-      );
-
-      it.each(ESCALATED)(
-        "%s leaves an explicit non-default max_tokens alone, even below the floor",
-        (model) => {
-          // A deliberate cost cap. Unlike the legacy branch (where Anthropic
-          // 400s if max_tokens <= budget_tokens, so overriding is mandatory),
-          // a short max_tokens here is legal — it truncates rather than
-          // erroring — so the caller's choice wins.
-          const output: Record<string, any> = { max_tokens: 2000 };
-          effortTransform("high", { model }, output);
-          expect(output.max_tokens).toBe(2000);
-        }
-      );
-
-      it("does not raise max_tokens when effort does not escalate", () => {
-        for (const model of ["claude-sonnet-5", "claude-sonnet-4-6"]) {
-          const output: Record<string, any> = { max_tokens: 4096 };
-          expect(effortTransform("high", { model }, output)).toBe("high");
-          expect(output.max_tokens).toBe(4096);
-        }
-      });
-
-      it.each(ESCALATED)(
-        "%s does not raise max_tokens below high effort",
-        (model) => {
-          for (const effort of ["minimal", "low", "medium"]) {
-            const output: Record<string, any> = { max_tokens: 4096 };
-            effortTransform(effort, { model }, output);
-            expect(output.max_tokens).toBe(4096);
-          }
-        }
-      );
-    });
-
     describe("legacy thinking (4.5 models)", () => {
       it.each([
         ["claude-sonnet-4-5-20250929", "minimal", 1024],

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -67,7 +67,10 @@ describe("anthropic config", () => {
         ["claude-opus-4-6", "high", "high"],
         ["claude-sonnet-4-6", "low", "low"],
         ["claude-sonnet-4-6", "high", "high"],
-        // Newer adaptive models (opus 4.8, sonnet 5, fable 5)
+        // Newer adaptive models (opus 5, opus 4.8, sonnet 5, fable 5)
+        ["claude-opus-5", "high", "xhigh"],
+        ["claude-opus-5", "minimal", "low"],
+        ["claude-opus-5", "medium", "medium"],
         ["claude-opus-4-8", "high", "xhigh"],
         ["claude-opus-4-8", "medium", "medium"],
         ["claude-sonnet-5", "high", "high"],
@@ -86,7 +89,7 @@ describe("anthropic config", () => {
     });
 
     describe("adaptive thinking maps high to xhigh for Opus coding flagships", () => {
-      it.each(["claude-opus-4-7", "claude-opus-4-8"])(
+      it.each(["claude-opus-5", "claude-opus-4-7", "claude-opus-4-8"])(
         "should map high to xhigh for %s",
         (model) => {
           const output: Record<string, any> = {};
@@ -272,6 +275,7 @@ describe("anthropic config", () => {
   describe("active shorthands", () => {
     it.each([
       ["anthropic.claude-fable-5", "claude-fable-5"],
+      ["anthropic.claude-opus-5", "claude-opus-5"],
       ["anthropic.claude-opus-4-8", "claude-opus-4-8"],
       ["anthropic.claude-sonnet-5", "claude-sonnet-5"],
       ["anthropic.claude-opus-4-7", "claude-opus-4-7"],
@@ -329,6 +333,18 @@ describe("anthropic config", () => {
     it("drops temperature, top_p, and top_k for claude-opus-4-8", () => {
       const body = buildBody({
         model: "claude-opus-4-8",
+        temperature: 0.5,
+        topP: 0.9,
+        topK: 40,
+      });
+      expect(body.temperature).toBeUndefined();
+      expect(body.top_p).toBeUndefined();
+      expect(body.top_k).toBeUndefined();
+    });
+
+    it("drops temperature, top_p, and top_k for claude-opus-5", () => {
+      const body = buildBody({
+        model: "claude-opus-5",
         temperature: 0.5,
         topP: 0.9,
         topK: 40,
@@ -486,6 +502,7 @@ describe("anthropic config", () => {
     });
 
     it.each([
+      ["anthropic.claude-opus-5"],
       ["anthropic.claude-opus-4-7"],
       ["anthropic.claude-opus-4-8"],
       ["anthropic.claude-sonnet-5"],

--- a/src/llm/config/anthropic/index.ts
+++ b/src/llm/config/anthropic/index.ts
@@ -8,6 +8,17 @@ import { cleanJsonSchemaFor } from "@/llm/output/_utils/cleanJsonSchemaFor";
 
 const ANTHROPIC_VERSION = "2023-06-01";
 
+// Referenced in two places that must agree: the `maxTokens` option default and
+// the escalated-effort floor below, which only raises a value it can identify
+// as "caller never chose one".
+const DEFAULT_MAX_TOKENS = 4096;
+
+// Thinking tokens count toward max_tokens. Anthropic's guidance for escalated
+// effort is to give the model room to think and act across tool calls (~64k as
+// a starting point); the default 4096 truncates on exactly the long-horizon
+// work the "xhigh" escalation exists for.
+const ESCALATED_EFFORT_MIN_MAX_TOKENS = 65536;
+
 // Models that 400 if temperature / top_p / top_k are set to non-default values.
 const MODELS_REJECTING_SAMPLING_PARAMS = [
   "claude-opus-5",
@@ -44,7 +55,7 @@ const anthropicChatV1: Config = {
     effort: {},
     maxTokens: {
       required: [true, "maxTokens required"],
-      default: 4096,
+      default: DEFAULT_MAX_TOKENS,
     },
     // Every key mapped in mapBody must also be declared here:
     // stateFromOptions picks only declared option keys, so an undeclared
@@ -140,7 +151,26 @@ const anthropicChatV1: Config = {
                 ? "xhigh"
                 : "high",
           };
-          return map[v];
+          const mapped = map[v];
+
+          // Raise the output ceiling for escalated effort, but ONLY when
+          // max_tokens is still the config default — that is the one value we
+          // can attribute to "caller never chose one". Any other value is a
+          // deliberate cost cap and is left alone even if it will truncate.
+          //
+          // The legacy branch below overrides max_tokens unconditionally; that
+          // is not an inconsistency to "fix". There, Anthropic 400s whenever
+          // max_tokens <= budget_tokens, so overriding is the only way to send
+          // a valid request. Here 4096 is perfectly legal, just short, so
+          // silently discarding a caller's explicit number would be wrong.
+          if (
+            mapped === "xhigh" &&
+            _output.max_tokens === DEFAULT_MAX_TOKENS
+          ) {
+            _output.max_tokens = ESCALATED_EFFORT_MIN_MAX_TOKENS;
+          }
+
+          return mapped;
         }
 
         const isLegacy =

--- a/src/llm/config/anthropic/index.ts
+++ b/src/llm/config/anthropic/index.ts
@@ -10,6 +10,7 @@ const ANTHROPIC_VERSION = "2023-06-01";
 
 // Models that 400 if temperature / top_p / top_k are set to non-default values.
 const MODELS_REJECTING_SAMPLING_PARAMS = [
+  "claude-opus-5",
   "claude-opus-4-7",
   "claude-opus-4-8",
   "claude-sonnet-5",
@@ -112,6 +113,7 @@ const anthropicChatV1: Config = {
         const model: string = _s.model || "";
 
         const isAdaptive =
+          model.startsWith("claude-opus-5") ||
           model.startsWith("claude-opus-4-6") ||
           model.startsWith("claude-opus-4-7") ||
           model.startsWith("claude-opus-4-8") ||
@@ -120,6 +122,9 @@ const anthropicChatV1: Config = {
           model.startsWith("claude-fable-5");
 
         if (isAdaptive) {
+          // Opus 5 already runs adaptive thinking when `thinking` is omitted;
+          // sending it explicitly is equivalent and keeps one code path for the
+          // whole adaptive generation (4.6/4.7/4.8 need it stated to think).
           _output.thinking = { type: "adaptive" };
           const map: Record<string, string> = {
             minimal: "low",
@@ -129,6 +134,7 @@ const anthropicChatV1: Config = {
             // effort (per the Opus 4.7 coding/agentic recommendation); other
             // adaptive models use "high".
             high:
+              model.startsWith("claude-opus-5") ||
               model.startsWith("claude-opus-4-7") ||
               model.startsWith("claude-opus-4-8")
                 ? "xhigh"
@@ -196,6 +202,9 @@ export const anthropic = {
     anthropicChatV1,
     "claude-fable-5"
   ),
+
+  // Claude Opus 5 models
+  "anthropic.claude-opus-5": withDefaultModel(anthropicChatV1, "claude-opus-5"),
 
   // Claude 4.8 models
   "anthropic.claude-opus-4-8": withDefaultModel(

--- a/src/llm/config/anthropic/index.ts
+++ b/src/llm/config/anthropic/index.ts
@@ -141,11 +141,13 @@ const anthropicChatV1: Config = {
             minimal: "low",
             low: "low",
             medium: "medium",
-            // Opus coding flagships take Anthropic's escalated "xhigh" for high
-            // effort (per the Opus 4.7 coding/agentic recommendation); other
-            // adaptive models use "high".
+            // Opus 4.7 and 4.8 escalate "high" to "xhigh": Anthropic's per-model
+            // guidance is to start with xhigh for coding/agentic work on those.
+            // Opus 5 is deliberately NOT escalated: Anthropic recommends starting
+            // with "high" (the default) on Opus 5 and explicitly warns against
+            // carrying the 4.x effort escalation over, so "high" must stay
+            // reachable. All other adaptive models also map "high" -> "high".
             high:
-              model.startsWith("claude-opus-5") ||
               model.startsWith("claude-opus-4-7") ||
               model.startsWith("claude-opus-4-8")
                 ? "xhigh"

--- a/src/llm/config/anthropic/index.ts
+++ b/src/llm/config/anthropic/index.ts
@@ -8,17 +8,6 @@ import { cleanJsonSchemaFor } from "@/llm/output/_utils/cleanJsonSchemaFor";
 
 const ANTHROPIC_VERSION = "2023-06-01";
 
-// Referenced in two places that must agree: the `maxTokens` option default and
-// the escalated-effort floor below, which only raises a value it can identify
-// as "caller never chose one".
-const DEFAULT_MAX_TOKENS = 4096;
-
-// Thinking tokens count toward max_tokens. Anthropic's guidance for escalated
-// effort is to give the model room to think and act across tool calls (~64k as
-// a starting point); the default 4096 truncates on exactly the long-horizon
-// work the "xhigh" escalation exists for.
-const ESCALATED_EFFORT_MIN_MAX_TOKENS = 65536;
-
 // Models that 400 if temperature / top_p / top_k are set to non-default values.
 const MODELS_REJECTING_SAMPLING_PARAMS = [
   "claude-opus-5",
@@ -55,7 +44,7 @@ const anthropicChatV1: Config = {
     effort: {},
     maxTokens: {
       required: [true, "maxTokens required"],
-      default: DEFAULT_MAX_TOKENS,
+      default: 4096,
     },
     // Every key mapped in mapBody must also be declared here:
     // stateFromOptions picks only declared option keys, so an undeclared
@@ -153,26 +142,7 @@ const anthropicChatV1: Config = {
                 ? "xhigh"
                 : "high",
           };
-          const mapped = map[v];
-
-          // Raise the output ceiling for escalated effort, but ONLY when
-          // max_tokens is still the config default — that is the one value we
-          // can attribute to "caller never chose one". Any other value is a
-          // deliberate cost cap and is left alone even if it will truncate.
-          //
-          // The legacy branch below overrides max_tokens unconditionally; that
-          // is not an inconsistency to "fix". There, Anthropic 400s whenever
-          // max_tokens <= budget_tokens, so overriding is the only way to send
-          // a valid request. Here 4096 is perfectly legal, just short, so
-          // silently discarding a caller's explicit number would be wrong.
-          if (
-            mapped === "xhigh" &&
-            _output.max_tokens === DEFAULT_MAX_TOKENS
-          ) {
-            _output.max_tokens = ESCALATED_EFFORT_MIN_MAX_TOKENS;
-          }
-
-          return mapped;
+          return map[v];
         }
 
         const isLegacy =

--- a/src/llm/config/anthropic/promptSanitize.test.ts
+++ b/src/llm/config/anthropic/promptSanitize.test.ts
@@ -145,6 +145,7 @@ describe("anthropicPromptSanitize", () => {
     });
 
     it.each([
+      "claude-opus-5",
       "claude-opus-4-8",
       "claude-sonnet-5",
       "claude-fable-5",

--- a/src/llm/config/anthropic/promptSanitize.ts
+++ b/src/llm/config/anthropic/promptSanitize.ts
@@ -6,14 +6,15 @@ import {
 
 // Models that 400 on a trailing assistant message (prefill): the 4.6+/5
 // generation. Issue #503 and Anthropic's migration guide name opus-4-6,
-// opus-4-7, and sonnet-4-6; opus-4-8, sonnet-5, and fable-5 belong to the same
-// generation and are grouped here for the same reason the sampling-param and
-// adaptive-thinking lists in `anthropic/index.ts` group this generation. The
-// 4.5 generation (opus/sonnet/haiku 4.5) still supports prefills and is
-// excluded. Kept as its own list because prefill support is a distinct model
-// capability from adaptive thinking / sampling-param handling, even though the
-// membership currently coincides.
+// opus-4-7, and sonnet-4-6; opus-5, opus-4-8, sonnet-5, and fable-5 belong to
+// the same generation and are grouped here for the same reason the
+// sampling-param and adaptive-thinking lists in `anthropic/index.ts` group this
+// generation. The 4.5 generation (opus/sonnet/haiku 4.5) still supports
+// prefills and is excluded. Kept as its own list because prefill support is a
+// distinct model capability from adaptive thinking / sampling-param handling,
+// even though the membership currently coincides.
 const PREFILL_UNSUPPORTED_MODELS = [
+  "claude-opus-5",
   "claude-opus-4-6",
   "claude-opus-4-7",
   "claude-opus-4-8",


### PR DESCRIPTION
## Problem

`claude-opus-5` was not recognized anywhere in `src/` — `grep -rn "claude-opus-5" src/` returned nothing. A request pinned to that model (via the options-based path, since there was no shorthand) fell through every model-membership check in the Anthropic config:

- **`effort` was silently dropped.** The transform tests `isAdaptive`, then `isLegacy`, then returns `undefined`. Opus 5 matched neither, so no `output_config.effort` and no `thinking` block were emitted. The caller's only remaining lever on cost and latency was total `max_tokens`, which bounds truncation but not spend.
- **Sampling params were not stripped.** `MODELS_REJECTING_SAMPLING_PARAMS` covered 4.7 / 4.8 / sonnet-5 / fable-5 but not Opus 5, which rejects `temperature` / `top_p` / `top_k` with a 400. Latent rather than live for callers who leave them unset, but the guard that exists to catch it did not cover this model.
- **No prefill warning.** A trailing assistant message 400s on this generation; `PREFILL_UNSUPPORTED_MODELS` did not list Opus 5, so the request went out unwarned.
- **No shorthand.** `useLlm("anthropic.claude-opus-5")` threw *Invalid provider*.

## Changes

Four gates, plus the type key:

| Gate | File |
|---|---|
| `MODELS_REJECTING_SAMPLING_PARAMS` | `src/llm/config/anthropic/index.ts` |
| `isAdaptive` in the `effort` transform | `src/llm/config/anthropic/index.ts` |
| `PREFILL_UNSUPPORTED_MODELS` | `src/llm/config/anthropic/promptSanitize.ts` |
| Shorthand registration | `src/llm/config/anthropic/index.ts` |
| Shorthand type key | `src/interfaces/llm.ts` |

`high` maps to `high` for Opus 5 — Anthropic's per-model guidance is to start at the `high` default and warns against carrying effort settings over from earlier models. Only 4.7 and 4.8 escalate `high` to `xhigh`, per their own per-model guidance. `minimal`/`low`/`medium` are unchanged.

`thinking: { type: "adaptive" }` is set explicitly even though Opus 5 already runs adaptive when `thinking` is omitted. The two are equivalent, and stating it keeps a single code path across the adaptive generation — 4.6 / 4.7 / 4.8 do require it stated. Commented inline so it does not get removed as redundant later.

## Out of scope

- **Bedrock.** `amazon:anthropic.chat.v1` exposes no `effort` option and no per-model shorthands. It shares `anthropicPromptSanitize`, so it picks up the prefill warning for free; wiring effort through there is a separate change.
- **`thinking: { type: "disabled" }` and `effort: "max"`.** Still unsupported. `max` is a normalization decision (llm-exe's effort vocabulary is `minimal | low | medium | high` across providers). `disabled` needs a guard for the effort-≤-`high` constraint before it can be exposed safely.
- **Exact-match vs prefix matching.** `MODELS_REJECTING_SAMPLING_PARAMS` uses `.includes(body.model)` (exact) while `isAdaptive` and `PREFILL_UNSUPPORTED_MODELS` use prefix matching. A dated snapshot such as `claude-opus-5-20260115` therefore gets adaptive thinking and the prefill warning but not the sampling-param strip. This is pre-existing and affects all five models on that list; it should get its own issue rather than being folded in here.

## Testing

Extended the six existing model-membership test tables rather than adding parallel ones — effort transform, xhigh escalation, active shorthands, `buildBody` sampling-param drop, end-to-end shorthand sampling drop, and the prefill warning.

- `npm run typecheck` — clean
- `npm test` — 194 suites, 2676 tests, all passing

## Semver

Minor. New shorthand and new model coverage, fully backwards-compatible; no existing behavior or types change.
