### PR TITLE
docs(anthropic): document effort option + fix sampling-param reject list

### DIFF
--- a/docs/llm/anthropic.options.part.md
+++ b/docs/llm/anthropic.options.part.md
@@ -1,19 +1,21 @@
-| Option          | Type    | Default           | Description                                                                      |
-| --------------- | ------- | ----------------- | -------------------------------------------------------------------------------- |
-| anthropicApiKey | string  | undefined         | API key for Anthropic. Optionally can be set using process.env.ANTHROPIC_API_KEY |
-| model           | string  | —                 | The model to use. Must be specified when using `anthropic.chat.v1`.              |
-| temperature     | number  | undefined         | Maps to temperature. See Anthropic Docs                                          |
-| maxTokens       | number  | 4096              | Maps to max_tokens. See Anthropic Docs                                           |
-| topP            | number  | undefined         | Maps to top_p. See Anthropic Docs                                                |
-| topK            | number  | undefined         | Maps to top_k. See Anthropic Docs                                                |
-| stopSequences   | array   | undefined         | Maps to stop_sequences. See Anthropic Docs                                       |
-| stream          | boolean | undefined         | Note: Not supported yet.                                                         |
-| metadata        | object  | undefined         | Maps to metadata. See Anthropic Docs                                             |
-| serviceTier     | string  | undefined         | Maps to service_tier. See Anthropic Docs                                         |
+| Option          | Type    | Default   | Description                                                                      |
+| --------------- | ------- | --------- | -------------------------------------------------------------------------------- |
+| anthropicApiKey | string  | undefined | API key for Anthropic. Optionally can be set using process.env.ANTHROPIC_API_KEY |
+| model           | string  | —         | The model to use. Must be specified when using `anthropic.chat.v1`.              |
+| temperature     | number  | undefined | Maps to temperature. See Anthropic Docs                                          |
+| maxTokens       | number  | 4096      | Maps to max_tokens. See Anthropic Docs                                           |
+| effort          | string  | undefined | Maps to reasoning effort / thinking. See the effort note below.                  |
+| topP            | number  | undefined | Maps to top_p. See Anthropic Docs                                                |
+| topK            | number  | undefined | Maps to top_k. See Anthropic Docs                                                |
+| stopSequences   | array   | undefined | Maps to stop_sequences. See Anthropic Docs                                       |
+| stream          | boolean | undefined | Note: Not supported yet.                                                         |
+| metadata        | object  | undefined | Maps to metadata. See Anthropic Docs                                             |
+| serviceTier     | string  | undefined | Maps to service_tier. See Anthropic Docs                                         |
 
 > [!NOTE]
-> **Sampling parameter restrictions:** `claude-opus-4-7` rejects requests that include `temperature`, `topP`, or `topK` — llm-exe silently drops these for that model. For other Claude 4.x models, `topP` is silently dropped when `temperature` is also set, because the Anthropic API does not allow both simultaneously.
->
-> **`maxTokens` default with escalated effort:** For `claude-opus-4-7` and `claude-opus-4-8`, llm-exe escalates `effort: "high"` to Anthropic's `xhigh`. In that case only, if you do not pass `maxTokens`, the default is raised from 4096 to 65536 so adaptive thinking is not truncated (Anthropic recommends a large `max_tokens` at `xhigh`). An explicit `maxTokens` (any value, including 4096) is always honored, and every other model keeps the 4096 default.
+> **Sampling parameter restrictions:** `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, and `claude-fable-5` reject requests that include `temperature`, `topP`, or `topK` — llm-exe silently drops these for those models. For other Claude 4.x models, `topP` is silently dropped when `temperature` is also set, because the Anthropic API does not allow both simultaneously.
+
+> [!NOTE]
+> **`effort`:** Accepts `minimal`/`low`/`medium`/`high`. For the adaptive generation (Opus 4.6 / 4.7 / 4.8 / 5, Sonnet 4.6 / 5, Fable 5) it sets `output_config.effort` and adaptive `thinking`; `high` escalates to `xhigh` on Opus 4.7 / 4.8, and in that escalated case, if you do not pass `maxTokens`, its default is raised from 4096 to 65536 so adaptive thinking is not truncated (an explicit `maxTokens` is always honored). For the 4.5 generation it sets extended-thinking `budget_tokens` and raises `max_tokens` above the budget. Because `effort` enables thinking, and Anthropic disallows sampling parameters while thinking is active, omit `topP` (or set it `>= 0.95`) when using `effort` — a lower `topP` returns a 400.
 
 Anthropic Docs: [link](https://docs.anthropic.com/en/api/messages)

--- a/docs/llm/anthropic.options.part.md
+++ b/docs/llm/anthropic.options.part.md
@@ -1,21 +1,22 @@
-| Option          | Type    | Default   | Description                                                                      |
-| --------------- | ------- | --------- | -------------------------------------------------------------------------------- |
-| anthropicApiKey | string  | undefined | API key for Anthropic. Optionally can be set using process.env.ANTHROPIC_API_KEY |
-| model           | string  | —         | The model to use. Must be specified when using `anthropic.chat.v1`.              |
-| temperature     | number  | undefined | Maps to temperature. See Anthropic Docs                                          |
-| maxTokens       | number  | 4096      | Maps to max_tokens. See Anthropic Docs                                           |
-| effort          | string  | undefined | Maps to reasoning effort / thinking. See the effort note below.                  |
-| topP            | number  | undefined | Maps to top_p. See Anthropic Docs                                                |
-| topK            | number  | undefined | Maps to top_k. See Anthropic Docs                                                |
-| stopSequences   | array   | undefined | Maps to stop_sequences. See Anthropic Docs                                       |
-| stream          | boolean | undefined | Note: Not supported yet.                                                         |
-| metadata        | object  | undefined | Maps to metadata. See Anthropic Docs                                             |
-| serviceTier     | string  | undefined | Maps to service_tier. See Anthropic Docs                                         |
+| Option          | Type    | Default           | Description                                                                      |
+| --------------- | ------- | ----------------- | -------------------------------------------------------------------------------- |
+| anthropicApiKey | string  | undefined         | API key for Anthropic. Optionally can be set using process.env.ANTHROPIC_API_KEY |
+| model           | string  | —                 | The model to use. Must be specified when using `anthropic.chat.v1`.              |
+| temperature     | number  | undefined         | Maps to temperature. See Anthropic Docs                                          |
+| maxTokens       | number  | 4096              | Maps to max_tokens. See Anthropic Docs                                           |
+| effort          | string  | undefined         | Maps to reasoning effort / thinking. See the effort note below.                  |
+| topP            | number  | undefined         | Maps to top_p. See Anthropic Docs                                                |
+| topK            | number  | undefined         | Maps to top_k. See Anthropic Docs                                                |
+| stopSequences   | array   | undefined         | Maps to stop_sequences. See Anthropic Docs                                       |
+| stream          | boolean | undefined         | Note: Not supported yet.                                                         |
+| metadata        | object  | undefined         | Maps to metadata. See Anthropic Docs                                             |
+| serviceTier     | string  | undefined         | Maps to service_tier. See Anthropic Docs                                         |
 
 > [!NOTE]
 > **Sampling parameter restrictions:** `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, and `claude-fable-5` reject requests that include `temperature`, `topP`, or `topK` — llm-exe silently drops these for those models. For other Claude 4.x models, `topP` is silently dropped when `temperature` is also set, because the Anthropic API does not allow both simultaneously.
-
-> [!NOTE]
-> **`effort`:** Accepts `minimal`/`low`/`medium`/`high`. For the adaptive generation (Opus 4.6 / 4.7 / 4.8 / 5, Sonnet 4.6 / 5, Fable 5) it sets `output_config.effort` and adaptive `thinking`; `high` escalates to `xhigh` on Opus 4.7 / 4.8, and in that escalated case, if you do not pass `maxTokens`, its default is raised from 4096 to 65536 so adaptive thinking is not truncated (an explicit `maxTokens` is always honored). For the 4.5 generation it sets extended-thinking `budget_tokens` and raises `max_tokens` above the budget. Because `effort` enables thinking, and Anthropic disallows sampling parameters while thinking is active, omit `topP` (or set it `>= 0.95`) when using `effort` — a lower `topP` returns a 400.
+>
+> **`effort`:** Accepts `minimal`/`low`/`medium`/`high` (silently ignored on models that do not support reasoning, e.g. Claude 3.x). For the adaptive generation (Opus 4.6 / 4.7 / 4.8 / 5, Sonnet 4.6 / 5, Fable 5) it sets `output_config.effort` and adaptive `thinking`; `high` escalates to `xhigh` on Opus 4.7 / 4.8, and in that escalated case, if you do not pass `maxTokens`, its default is raised from 4096 to 65536 so adaptive thinking is not truncated (an explicit `maxTokens` is always honored). For the 4.5 generation it sets extended-thinking `budget_tokens` and raises `max_tokens` above the budget.
+>
+> Because `effort` enables thinking, Anthropic rejects sampling parameters in the same request: `temperature` and `topK` must be unset, and `topP` must be unset or `>= 0.95`. For the models in the sampling-restriction note above, llm-exe already drops all three, so nothing changes. For the models that otherwise allow sampling — Opus 4.6, Sonnet 4.6, and the 4.5 generation — combining `effort` with `temperature`, `topK`, or a `topP` below 0.95 currently returns a 400; omit them.
 
 Anthropic Docs: [link](https://docs.anthropic.com/en/api/messages)


### PR DESCRIPTION
## Summary

Small docs sync for the direct Anthropic provider, flagged in the #715 reviews (the gaps are pre-existing from #711/#713):

- **Adds the missing `effort` row** to the options table.
- **Adds an `effort` note**: accepts `minimal`/`low`/`medium`/`high` (silently ignored on non-reasoning models like Claude 3.x); sets `output_config.effort` + adaptive `thinking` on the 4.6+/5 generation (`high` → `xhigh` on Opus 4.7/4.8, which raises the `maxTokens` default to 65536 in that escalated case); sets extended-thinking `budget_tokens` on the 4.5 generation. Folds in the previous standalone maxTokens-escalation note. A second paragraph documents the thinking/sampling incompatibility precisely: `temperature`/`topK` must be unset and `topP` unset or `>= 0.95`; the reject-list models already drop all three, while Opus 4.6 / Sonnet 4.6 / the 4.5 generation currently 400 when `effort` is combined with a sampling param.
- **Corrects the sampling-param reject list** — it said only `claude-opus-4-7`; the actual list is `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`.

## Scope

Docs only, single file (`docs/llm/anthropic.options.part.md`, which is `@include`d into `anthropic.md`). Only the `effort` row and the two notes change — the rest of the table is untouched (no realignment). `docs/public/llms-full.txt` regenerates from this via `predocs:build`; deliberately not regenerated here (per the #715 review it sweeps in unrelated accumulated drift).

The reject-list correction stands on its own. The `effort` row/note also gives the pending #715 (Bedrock effort) a landing spot for its "See Anthropic provider" cross-reference — on `development` today the Bedrock docs have no `effort` mention yet, so this closes that gap ahead of #715 merging.

No code changes; behavior described matches `development` (Opus 5 + the #712 effort/floor are merged). The broader "normalize sampling params when effort enables thinking" behavior change is tracked in #716.
