### PR TITLE
fix(anthropic): drop sampling params when effort enables thinking (#716)

### DIFF
--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -337,6 +337,34 @@ describe("anthropic config", () => {
       expect(body.max_tokens).toBe(4096);
     });
 
+    it("drops temperature/topP/topK when effort enables thinking on a non-reject adaptive model (issue #716)", () => {
+      const body = mapBody(config.mapBody, {
+        model: "claude-sonnet-4-6",
+        maxTokens: 4096,
+        effort: "high",
+        temperature: 0.5,
+        topP: 0.9,
+        topK: 40,
+        prompt,
+      });
+      expect(body.thinking).toEqual({ type: "adaptive" });
+      expect(body.temperature).toBeUndefined();
+      expect(body.top_p).toBeUndefined();
+      expect(body.top_k).toBeUndefined();
+    });
+
+    it("keeps topP >= 0.95 when effort enables thinking (issue #716)", () => {
+      const body = mapBody(config.mapBody, {
+        model: "claude-sonnet-4-6",
+        maxTokens: 4096,
+        effort: "high",
+        topP: 0.97,
+        prompt,
+      });
+      expect(body.thinking).toEqual({ type: "adaptive" });
+      expect(body.top_p).toBe(0.97);
+    });
+
     it("should not add thinking fields for claude-3 models", () => {
       const body = mapBody(config.mapBody, {
         model: "claude-3-5-sonnet-latest",

--- a/src/llm/config/anthropic/effort.test.ts
+++ b/src/llm/config/anthropic/effort.test.ts
@@ -157,4 +157,90 @@ describe("anthropic effort (shared direct + bedrock)", () => {
       ).toBe(40);
     });
   });
+
+  // issue #716: effort enables thinking, and Anthropic forbids sampling params
+  // while thinking is active (temperature/top_k unset, top_p unset or >= 0.95).
+  // These models normally ALLOW sampling (not on the unconditional reject list),
+  // so the drop must be gated on effort, not on the model alone.
+  describe("sampling params dropped when effort enables thinking (issue #716)", () => {
+    // Two adaptive 4.6 models + the three 4.5 legacy models: allow sampling
+    // without effort, but effort turns on thinking.
+    const thinkingModels = [
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-opus-4-5",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+    ];
+
+    describe.each(thinkingModels)("%s with effort:'high'", (model) => {
+      it("drops temperature and topK", () => {
+        expect(
+          dropIfModelRejectsSamplingParams(0.5, { model, effort: "high" })
+        ).toBeUndefined();
+        expect(
+          dropIfModelRejectsSamplingParams(40, { model, effort: "high" })
+        ).toBeUndefined();
+      });
+
+      it("drops topP below 0.95", () => {
+        expect(topPTransform(0.9, { model, effort: "high" })).toBeUndefined();
+        expect(topPTransform(0.94, { model, effort: "high" })).toBeUndefined();
+      });
+
+      it("keeps topP at or above 0.95", () => {
+        expect(topPTransform(0.95, { model, effort: "high" })).toBe(0.95);
+        expect(topPTransform(0.99, { model, effort: "high" })).toBe(0.99);
+      });
+    });
+
+    it("keeps sampling params when no effort is set (thinking off)", () => {
+      expect(
+        dropIfModelRejectsSamplingParams(0.5, { model: "claude-sonnet-4-6" })
+      ).toBe(0.5);
+      expect(topPTransform(0.9, { model: "claude-sonnet-4-6" })).toBe(0.9);
+    });
+
+    it("keeps sampling params when effort targets a non-thinking model (Claude 3.x)", () => {
+      const body = { model: "claude-3-5-sonnet-latest", effort: "high" };
+      expect(dropIfModelRejectsSamplingParams(0.5, body)).toBe(0.5);
+      expect(topPTransform(0.9, body)).toBe(0.9);
+    });
+
+    it("keeps sampling params when effort is an invalid value", () => {
+      expect(
+        dropIfModelRejectsSamplingParams(0.5, {
+          model: "claude-sonnet-4-6",
+          effort: "max",
+        })
+      ).toBe(0.5);
+      expect(
+        topPTransform(0.9, { model: "claude-sonnet-4-6", effort: "nonsense" })
+      ).toBe(0.9);
+    });
+
+    it("reject-list models still drop topP unconditionally, even topP >= 0.95", () => {
+      // opus-4-8 rejects sampling params regardless of thinking, so the >= 0.95
+      // carve-out does not apply and 0.99 is still dropped.
+      expect(
+        topPTransform(0.99, { model: "claude-opus-4-8", effort: "high" })
+      ).toBeUndefined();
+      expect(topPTransform(0.99, { model: "claude-opus-4-8" })).toBeUndefined();
+    });
+
+    it("applies to Bedrock invoke IDs (canonicalized)", () => {
+      expect(
+        topPTransform(0.9, {
+          model: "us.anthropic.claude-sonnet-4-6",
+          effort: "high",
+        })
+      ).toBeUndefined();
+      expect(
+        topPTransform(0.96, {
+          model: "us.anthropic.claude-sonnet-4-6",
+          effort: "high",
+        })
+      ).toBe(0.96);
+    });
+  });
 });

--- a/src/llm/config/anthropic/effort.ts
+++ b/src/llm/config/anthropic/effort.ts
@@ -19,6 +19,13 @@ const MODELS_REJECTING_SAMPLING_PARAMS = [
   "claude-fable-5",
 ];
 
+// Caller-facing effort values, mapped to provider effort/thinking shapes below.
+// Anything else is ignored (no thinking enabled).
+const EFFORT_VALUES = ["minimal", "low", "medium", "high"];
+
+// When thinking is active, Anthropic requires top_p to be unset or >= this value.
+const THINKING_MIN_TOP_P = 0.95;
+
 // Normalize a provider model identifier to the canonical "claude-..." name the
 // gates below match against. The direct Anthropic API uses bare names
 // ("claude-opus-4-8"); Amazon Bedrock uses invoke identifiers such as
@@ -50,6 +57,22 @@ export function canonicalAnthropicModel(model: string): string {
 const matchesModel = (canonical: string, name: string): boolean =>
   canonical === name || canonical.startsWith(`${name}-`);
 
+// Adaptive-thinking generation: effort sets output_config.effort + adaptive thinking.
+const isAdaptiveModel = (canonical: string): boolean =>
+  matchesModel(canonical, "claude-opus-5") ||
+  matchesModel(canonical, "claude-opus-4-6") ||
+  matchesModel(canonical, "claude-opus-4-7") ||
+  matchesModel(canonical, "claude-opus-4-8") ||
+  matchesModel(canonical, "claude-sonnet-4-6") ||
+  matchesModel(canonical, "claude-sonnet-5") ||
+  matchesModel(canonical, "claude-fable-5");
+
+// Legacy (4.5) generation: effort sets thinking { type: "enabled", budget_tokens }.
+const isLegacyThinkingModel = (canonical: string): boolean =>
+  matchesModel(canonical, "claude-opus-4-5") ||
+  matchesModel(canonical, "claude-sonnet-4-5") ||
+  matchesModel(canonical, "claude-haiku-4-5");
+
 const modelRejectsSamplingParams = (model: string): boolean => {
   const canonical = canonicalAnthropicModel(model);
   return MODELS_REJECTING_SAMPLING_PARAMS.some((name) =>
@@ -57,17 +80,46 @@ const modelRejectsSamplingParams = (model: string): boolean => {
   );
 };
 
+// True when the caller's `effort` will turn on thinking for this model. Anthropic
+// forbids sampling params while thinking is active (temperature / top_k must be
+// unset, top_p unset or >= 0.95), so the sampling transforms use this to drop the
+// incompatible params rather than forward them into a guaranteed 400 (issue #716).
+// `effort` is the only option that enables thinking (there is no `thinking`
+// passthrough on either config), so this is a complete check. It reads `effort`
+// from the (frozen) state, not `_output.thinking`, because the sampling transforms
+// run before the effort transform in the mapBody template order.
+const effortEnablesThinking = (model: string, effort: unknown): boolean => {
+  if (typeof effort !== "string" || !EFFORT_VALUES.includes(effort)) {
+    return false;
+  }
+  const canonical = canonicalAnthropicModel(model || "");
+  return isAdaptiveModel(canonical) || isLegacyThinkingModel(canonical);
+};
+
 // Claude 4.x rejects requests that set both temperature and top_p; keep temperature.
 const isClaude4x = (model: string) =>
   /^claude-(opus|sonnet|haiku)-4-/.test(canonicalAnthropicModel(model));
 
+// Used for temperature / top_k: drop when the model rejects sampling params
+// unconditionally, OR when effort enables thinking (temperature / top_k must be
+// unset while thinking is active).
 export const dropIfModelRejectsSamplingParams = (
   v: any,
   body: Record<string, any>
-) => (modelRejectsSamplingParams(body.model) ? undefined : v);
+) =>
+  modelRejectsSamplingParams(body.model) ||
+  effortEnablesThinking(body.model, body.effort)
+    ? undefined
+    : v;
 
 export const topPTransform = (v: any, body: Record<string, any>) => {
   if (modelRejectsSamplingParams(body.model)) return undefined;
+  // Thinking (enabled via effort) requires top_p unset or >= 0.95. Checked before
+  // the Claude 4.x temperature rule so an adaptive 4.x model uses the thinking
+  // constraint rather than the temperature one.
+  if (effortEnablesThinking(body.model, body.effort)) {
+    return typeof v === "number" && v >= THINKING_MIN_TOP_P ? v : undefined;
+  }
   if (isClaude4x(body.model) && body.temperature !== undefined) return undefined;
   return v;
 };
@@ -83,25 +135,13 @@ export const effortTransform = (
   _s: Record<string, any>,
   _output: Record<string, any>
 ) => {
-  if (
-    typeof v !== "string" ||
-    !["minimal", "low", "medium", "high"].includes(v)
-  ) {
+  if (typeof v !== "string" || !EFFORT_VALUES.includes(v)) {
     return undefined;
   }
 
   const model = canonicalAnthropicModel(_s.model || "");
 
-  const isAdaptive =
-    matchesModel(model, "claude-opus-5") ||
-    matchesModel(model, "claude-opus-4-6") ||
-    matchesModel(model, "claude-opus-4-7") ||
-    matchesModel(model, "claude-opus-4-8") ||
-    matchesModel(model, "claude-sonnet-4-6") ||
-    matchesModel(model, "claude-sonnet-5") ||
-    matchesModel(model, "claude-fable-5");
-
-  if (isAdaptive) {
+  if (isAdaptiveModel(model)) {
     // Opus 5 already runs adaptive thinking when `thinking` is omitted; sending
     // it explicitly is equivalent and keeps one code path for the whole adaptive
     // generation (4.6/4.7/4.8 need it stated to think).
@@ -150,12 +190,7 @@ export const effortTransform = (
     return mapped;
   }
 
-  const isLegacy =
-    matchesModel(model, "claude-opus-4-5") ||
-    matchesModel(model, "claude-sonnet-4-5") ||
-    matchesModel(model, "claude-haiku-4-5");
-
-  if (isLegacy) {
+  if (isLegacyThinkingModel(model)) {
     const budgetMap: Record<string, number> = {
       minimal: 1024,
       low: 4096,

--- a/src/llm/config/bedrock/bedrock.test.ts
+++ b/src/llm/config/bedrock/bedrock.test.ts
@@ -142,6 +142,25 @@ describe("bedrock configuration", () => {
       expect(body.top_p).toBe(0.9);
     });
 
+    it("drops top_p on a non-reject model when effort enables thinking (issue #716)", () => {
+      const body = bodyWith(
+        "us.anthropic.claude-sonnet-4-6",
+        { effort: "high", topP: 0.9 },
+        ["effort", "topP"]
+      );
+      expect(body.thinking).toEqual({ type: "adaptive" });
+      expect(body.top_p).toBeUndefined();
+    });
+
+    it("keeps top_p >= 0.95 on a non-reject model when effort enables thinking (issue #716)", () => {
+      const body = bodyWith(
+        "us.anthropic.claude-sonnet-4-6",
+        { effort: "high", topP: 0.97 },
+        ["effort", "topP"]
+      );
+      expect(body.top_p).toBe(0.97);
+    });
+
     it("adds no effort/thinking fields when effort is not provided", () => {
       const body = bodyWith("us.anthropic.claude-opus-4-8", {}, []);
       expect(body).not.toHaveProperty("output_config");


### PR DESCRIPTION
## Summary

Closes #716.

Anthropic forbids sampling parameters while thinking is active: `temperature`/`top_k` must be unset, and `top_p` must be unset or `>= 0.95`. llm-exe only dropped sampling params for the models that reject them **unconditionally** (the reject list), so a model that normally allows sampling — **Opus 4.6, Sonnet 4.6, and the 4.5 legacy generation** — but has thinking turned on via `effort` forwarded the param and 400ed. Pre-existing on the direct provider; surfaced on Bedrock while wiring `effort` in #715.

## Fix (shared effort module, both providers)

- Extract `isAdaptiveModel` / `isLegacyThinkingModel` predicates out of the effort transform, and add `effortEnablesThinking(model, effort)`.
- `dropIfModelRejectsSamplingParams` (temperature / top_k) now also drops when effort enables thinking.
- `topPTransform` drops `top_p` when effort enables thinking **unless it is `>= 0.95`** (which the API accepts with thinking) — checked before the Claude 4.x temperature rule so an adaptive 4.x model uses the thinking constraint.

`effortEnablesThinking` reads `effort` from the frozen state, not `_output.thinking`, because the sampling transforms run **before** the effort transform in the mapBody template order (moving `effort` earlier would break the #712 `max_tokens` floor, which depends on running after `maxTokens`). `effort` is the only path that enables thinking on either config, so gating on it is complete.

## Verification

**Live against Bedrock** (`us.anthropic.claude-sonnet-4-6`, real `useLlm` path):
```
effort:"high" + topP:0.9  -> llm-exe drops top_p -> 200  (was 400 before this fix)
effort:"high" + topP:0.97 -> top_p kept (>= 0.95) -> 200
```

**Tests:** the 5 affected models × `temperature`/`topK`/`topP` dropped under `effort`; `topP` `0.95`/`0.99` kept and `0.94` dropped; reject-list models still drop unconditionally (even `>= 0.95`); dated snapshots; Bedrock invoke IDs; regression guards (no `effort` / non-thinking model / invalid `effort` → sampling kept); plus end-to-end `mapBody` tests on both providers. `npm test` 197 suites / 2971, typecheck clean, build clean.

## Notes

- **Silent drop**, consistent with the existing reject-list convention.
- **Semver: patch** — only removes params the API rejects, so a currently-400ing request becomes valid; no working user code changes behavior.
- **Stacked on #715** (`feat/bedrock-anthropic-effort-overrides`), which creates `effort.ts` and the `canonicalAnthropicModel` / `matchesModel` primitives this builds on. Base retargets to `development` once #715 merges; please merge #715 first.
